### PR TITLE
Adding fix for array type hint on generated methods

### DIFF
--- a/src/ProxyManager/Generator/ParameterGenerator.php
+++ b/src/ProxyManager/Generator/ParameterGenerator.php
@@ -19,6 +19,7 @@
 namespace ProxyManager\Generator;
 
 use Zend\Code\Generator\ParameterGenerator as ZendParameterGenerator;
+use Zend\Code\Generator\ValueGenerator;
 use Zend\Code\Reflection\ParameterReflection;
 
 /**
@@ -84,5 +85,39 @@ class ParameterGenerator extends ZendParameterGenerator
         }
 
         return parent::setType($type);
+    }
+
+    /**
+     * @override fixes type hinting for arrays
+     *
+     * {@inheritDoc}
+     */
+    public function generate()
+    {
+        $output = '';
+
+        if ($this->type) {
+            $output .= $this->type . ' ';
+        }
+
+        if (true === $this->passedByReference) {
+            $output .= '&';
+        }
+
+        $output .= '$' . $this->name;
+
+        if ($this->defaultValue !== null) {
+            $output .= ' = ';
+            if (is_string($this->defaultValue)) {
+                $output .= ValueGenerator::escape($this->defaultValue);
+            } elseif ($this->defaultValue instanceof ValueGenerator) {
+                $this->defaultValue->setOutputMode(ValueGenerator::OUTPUT_SINGLE_LINE);
+                $output .= $this->defaultValue;
+            } else {
+                $output .= $this->defaultValue;
+            }
+        }
+
+        return $output;
     }
 }

--- a/tests/ProxyManagerTestAsset/BaseClass.php
+++ b/tests/ProxyManagerTestAsset/BaseClass.php
@@ -76,6 +76,16 @@ class BaseClass
     }
 
     /**
+     * @param array $param
+     *
+     * @return string
+     */
+    public function publicArrayHintedMethod(array $param)
+    {
+        return 'publicArrayHintedMethodDefault';
+    }
+
+    /**
      * @return string
      */
     public function & publicByReferenceMethod()


### PR DESCRIPTION
Introduces a polyfill that fixes behaviour of Zend\Code with array type hints
