### PR TITLE
Clarifying spots where 'virtual proxy' and 'smart reference' should be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ The suggested installation method is via [composer](https://getcomposer.org/):
 php composer.phar require ocramius/proxy-manager:0.3.*
 ```
 
-## Lazy Loading Value Holders
+## Lazy Loading Value Holders (Virtual Proxy)
 
-Currently, this library can generate [lazy loading value holders](http://www.martinfowler.com/eaaCatalog/lazyLoad.html),
-which are a way to save performance and memory for objects that require a lot of dependencies or CPU cycles to be
-initialized, and may not always be used.
+ProxyManager can generate [lazy loading value holders](http://www.martinfowler.com/eaaCatalog/lazyLoad.html),
+which are virtual proxies capable of saving performance and memory for objects that require a lot of dependencies or
+CPU cycles to be loaded: particularly useful when you may not always need the object, but are constructing it anyways.
 
 ```php
 $config  = new \ProxyManager\Configuration(); // customize this if needed for production
@@ -44,8 +44,9 @@ in the `docs/` directory.
 
 ## Access Interceptors
 
-An access interceptor allows you to execute logic before and after a particular method is executed or a particular
-property is accessed, and it allows to manipulate parameters and return values depending on your needs.
+An access interceptor is a smart reference that allows you to execute logic before and after a particular method
+is executed or a particular property is accessed, and it allows to manipulate parameters and return values depending
+on your needs.
 
 ```php
 $config  = new \ProxyManager\Configuration(); // customize this if needed for production
@@ -83,12 +84,12 @@ the context of data mappers.
 
 This feature is [planned](https://github.com/Ocramius/ProxyManager/issues/6).
 
-## Smart References
+## Lazy References
 
-A smart reference proxy is actually a proxy backed by some kind of reference holder (usually a registry) that can fetch
+A lazy reference proxy is actually a proxy backed by some kind of reference holder (usually a registry) that can fetch
 existing instances of a particular object.
 
-A smart reference is usually necessary when multiple instances of the same object can be avoided, or when the instances
+A lazy reference is usually necessary when multiple instances of the same object can be avoided, or when the instances
 are not hard links (like with [Weakref](http://php.net/manual/en/book.weakref.php)), and could be garbage-collected to
 save memory in long time running processes.
 

--- a/docs/access-interceptor-value-holder.md
+++ b/docs/access-interceptor-value-holder.md
@@ -1,10 +1,10 @@
 # Access Interceptor Value Holder Proxy
 
-An access interceptor value holder is a wrapper that allows you to dynamically
+An access interceptor value holder is a smart reference proxy that allows you to dynamically
 define logic to be executed before or after any of the wrapped object's methods
 logic.
 
-It can be useful for things like:
+It wraps around a real instance of the object to be proxied, and can be useful for things like:
 
  * caching execution of slow and heavy methods
  * log method calls

--- a/docs/lazy-loading-value-holder.md
+++ b/docs/lazy-loading-value-holder.md
@@ -1,6 +1,6 @@
 # Lazy Loading Value Holder Proxy
 
-A lazy loading value holder proxy is an object that is wrapping a lazily initialized "real" instance of the proxied
+A lazy loading value holder proxy is a virtual proxy that wraps and lazily initializes a "real" instance of the proxied
 class.
 
 ## What is lazy loading?


### PR DESCRIPTION
Currently, ProxyManager uses "lazy loading value holder" to refer to a "virtual proxy", and "access interceptor value holder" to refer to a "smart reference" (terms "virtual proxy" and "smart reference" come from GOF). This PR introduces some clarifications
