### PR TITLE
First implementation of interface support in ProxyManager

### DIFF
--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolderGenerator.php
@@ -58,10 +58,18 @@ class AccessInterceptorValueHolderGenerator implements ProxyGeneratorInterface
      */
     public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {
-        $classGenerator->setExtendedClass($originalClass->getName());
-        $classGenerator->setImplementedInterfaces(
-            array('ProxyManager\\Proxy\\AccessInterceptorInterface', 'ProxyManager\\Proxy\\ValueHolderInterface')
+        $interfaces = array(
+            'ProxyManager\\Proxy\\AccessInterceptorInterface',
+            'ProxyManager\\Proxy\\ValueHolderInterface',
         );
+
+        if ($originalClass->isInterface()) {
+            $interfaces[] = $originalClass->getName();
+        } else {
+            $classGenerator->setExtendedClass($originalClass->getName());
+        }
+
+        $classGenerator->setImplementedInterfaces($interfaces);
         $classGenerator->addPropertyFromGenerator($valueHolder = new ValueHolderProperty());
         $classGenerator->addPropertyFromGenerator($prefixInterceptors = new MethodPrefixInterceptors());
         $classGenerator->addPropertyFromGenerator($suffixInterceptors = new MethodPrefixInterceptors());

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
@@ -59,13 +59,18 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
      */
     public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {
-        $classGenerator->setExtendedClass($originalClass->getName());
-        $classGenerator->setImplementedInterfaces(
-            array(
-                'ProxyManager\\Proxy\\LazyLoadingInterface',
-                'ProxyManager\\Proxy\\ValueHolderInterface',
-            )
+        $interfaces = array(
+            'ProxyManager\\Proxy\\LazyLoadingInterface',
+            'ProxyManager\\Proxy\\ValueHolderInterface',
         );
+
+        if ($originalClass->isInterface()) {
+            $interfaces[] = $originalClass->getName();
+        } else {
+            $classGenerator->setExtendedClass($originalClass->getName());
+        }
+
+        $classGenerator->setImplementedInterfaces($interfaces);
         $classGenerator->addPropertyFromGenerator($valueHolder = new ValueHolderProperty());
         $classGenerator->addPropertyFromGenerator($initializer = new InitializerProperty());
 

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
@@ -40,9 +40,9 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
     /**
      * @dataProvider getProxyMethods
      */
-    public function testMethodCalls($instance, $method, $params, $expectedValue)
+    public function testMethodCalls($className, $instance, $method, $params, $expectedValue)
     {
-        $proxyName = $this->generateProxy(get_class($instance));
+        $proxyName = $this->generateProxy($className);
 
         /* @var $proxy \ProxyManager\Proxy\AccessInterceptorInterface|\ProxyManager\Proxy\ValueHolderInterface */
         $proxy     = new $proxyName($instance);
@@ -82,9 +82,9 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
     /**
      * @dataProvider getProxyMethods
      */
-    public function testMethodCallsWithSuffixListener($instance, $method, $params, $expectedValue)
+    public function testMethodCallsWithSuffixListener($className, $instance, $method, $params, $expectedValue)
     {
-        $proxyName = $this->generateProxy(get_class($instance));
+        $proxyName = $this->generateProxy($className);
 
         /* @var $proxy \ProxyManager\Proxy\AccessInterceptorInterface|\ProxyManager\Proxy\ValueHolderInterface */
         $proxy     = new $proxyName($instance);
@@ -120,9 +120,9 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
     /**
      * @dataProvider getProxyMethods
      */
-    public function testMethodCallsAfterUnSerialization($instance, $method, $params, $expectedValue)
+    public function testMethodCallsAfterUnSerialization($className, $instance, $method, $params, $expectedValue)
     {
-        $proxyName = $this->generateProxy(get_class($instance));
+        $proxyName = $this->generateProxy($className);
         /* @var $proxy \ProxyManager\Proxy\AccessInterceptorInterface|\ProxyManager\Proxy\ValueHolderInterface */
         $proxy     = unserialize(serialize(new $proxyName($instance)));
 
@@ -133,9 +133,9 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
     /**
      * @dataProvider getProxyMethods
      */
-    public function testMethodCallsAfterCloning($instance, $method, $params, $expectedValue)
+    public function testMethodCallsAfterCloning($className, $instance, $method, $params, $expectedValue)
     {
-        $proxyName = $this->generateProxy(get_class($instance));
+        $proxyName = $this->generateProxy($className);
 
         /* @var $proxy \ProxyManager\Proxy\AccessInterceptorInterface|\ProxyManager\Proxy\ValueHolderInterface */
         $proxy     = new $proxyName($instance);
@@ -223,14 +223,34 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
     public function getProxyMethods()
     {
         return array(
-            array(new BaseClass(), 'publicMethod', array(), 'publicMethodDefault'),
             array(
+                'ProxyManagerTestAsset\\BaseClass',
+                new BaseClass(),
+                'publicMethod',
+                array(),
+                'publicMethodDefault'
+            ),
+            array(
+                'ProxyManagerTestAsset\\BaseClass',
                 new BaseClass(),
                 'publicTypeHintedMethod',
                 array('param' => new \stdClass()),
                 'publicTypeHintedMethodDefault'
             ),
-            array(new BaseClass(), 'publicByReferenceMethod', array(), 'publicByReferenceMethodDefault'),
+            array(
+                'ProxyManagerTestAsset\\BaseClass',
+                new BaseClass(),
+                'publicByReferenceMethod',
+                array(),
+                'publicByReferenceMethodDefault'
+            ),
+            array(
+                'ProxyManagerTestAsset\\BaseInterface',
+                new BaseClass(),
+                'publicMethod',
+                array(),
+                'publicMethodDefault'
+            ),
         );
     }
 

--- a/tests/ProxyManagerTestAsset/BaseClass.php
+++ b/tests/ProxyManagerTestAsset/BaseClass.php
@@ -24,7 +24,7 @@ namespace ProxyManagerTestAsset;
  * @author Marco Pivetta <ocramius@gmail.com>
  * @license MIT
  */
-class BaseClass
+class BaseClass implements BaseInterface
 {
     /**
      * @var string

--- a/tests/ProxyManagerTestAsset/BaseInterface.php
+++ b/tests/ProxyManagerTestAsset/BaseInterface.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ProxyManagerTestAsset;
+
+/**
+ * Base interface used to verify that the proxy generators can actually work with interfaces
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @license MIT
+ */
+interface BaseInterface
+{
+    /**
+     * @return mixed
+     */
+    public function publicMethod();
+}


### PR DESCRIPTION
This PR allows to pass interface FQCNs instead of real class names to the proxy factories. That way, it is possible to save some performance by avoiding duplication of properties of the proxied objects.
