### PR TITLE
Update lazy-loading-ghost-object.md

### DIFF
--- a/docs/lazy-loading-ghost-object.md
+++ b/docs/lazy-loading-ghost-object.md
@@ -19,7 +19,7 @@ class MyObjectProxy
     {
         $this->init();
 
-        return $this->wrapped->doFoo();
+        // Perform doFoo routine using loaded variables
     }
 
     private function init()


### PR DESCRIPTION
Removed 

```
return $this->wrapped->doFoo();
```

From doFoo method as it implies the use of a wrapped instance (which as I understand it shouldn't be the case for a ghost object).
