### PR TITLE
Removing XDebug from performance test suite runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml --exclude-group Functional,Performance
   - ./vendor/bin/phpunit --group=Functional
-  - ./vendor/bin/phpunit --group=Performance
+  - php -n ./vendor/bin/phpunit --group=Performance
   - ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/
 
 after_script:


### PR DESCRIPTION
XDebug is interfering with the various performance benchmarks and should be disabled
