### PR TITLE
Remove useless code in the generation method (body content)

### DIFF
--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -61,9 +61,6 @@ class MethodGenerator extends ZendMethodGenerator
         /* @var $method self */
         $method = new static();
 
-        $method->setSourceContent($reflectionMethod->getContents(false));
-        $method->setSourceDirty(false);
-
         if ($reflectionMethod->getDocComment() != '') {
             $method->setDocBlock(DocBlockGenerator::fromReflection($reflectionMethod->getDocBlock()));
         }
@@ -84,7 +81,6 @@ class MethodGenerator extends ZendMethodGenerator
 
         $method->setStatic($reflectionMethod->isStatic());
         $method->setName($reflectionMethod->getName());
-        $method->setBody($reflectionMethod->getBody());
         $method->setReturnsReference($reflectionMethod->returnsReference());
 
         return $method;


### PR DESCRIPTION
A proxy rewrite a new content,so it's useless to have a default content in the body method
