### PR TITLE
Fix windows path length limitations

### DIFF
--- a/src/ProxyManager/Inflector/Util/ParameterEncoder.php
+++ b/src/ProxyManager/Inflector/Util/ParameterEncoder.php
@@ -36,6 +36,6 @@ class ParameterEncoder
      */
     public function encodeParameters(array $parameters)
     {
-        return strtr(base64_encode(serialize($parameters)), '+/=', '†‡•');
+        return strtr(base64_encode(gzcompress(serialize($parameters))), '+/=', '†‡•');
     }
 }


### PR DESCRIPTION
Patch is self-explanatory. Tests simply fail on the "awesome" microsoft OS.
