### PR TITLE
Update access-interceptor-scope-localizer.md

### DIFF
--- a/docs/access-interceptor-scope-localizer.md
+++ b/docs/access-interceptor-scope-localizer.md
@@ -65,7 +65,7 @@ would break an [access interceptor value holder](access-interceptor-value-holder
 
 ## Example
 
-Here's an example of how you can create and use an access interceptor value holder:
+Here's an example of how you can create and use an access interceptor scope localizer :
 
 ```php
 <?php


### PR DESCRIPTION
Corrected what is probably a mistake : is AccessInterceptorScopeLocalizer doc, there is "Here an example of how to use Access interceptor value holder", although we're talking about Access interceptor scope localizer.
