### PR TITLE
Upgrading PHPUnit to verify that sebastianbergmann/phpunit#1115 fixed ocramius/ProxyManager#140

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "phpunit/phpunit":             "~3.7",
         "phpmd/phpmd":                 "1.4.*",
         "squizlabs/php_codesniffer":   "1.4.*",
-        "satooshi/php-coveralls":      "~0.6",
-        "zendframework/zendframework": "~2.3"
+        "satooshi/php-coveralls":      "~0.6"
     },
     "suggest": {
         "zendframework/zend-stdlib":   "To use the hydrator proxy",


### PR DESCRIPTION
Depends on
- [x] sebastianbergmann/phpunit#1115
- [x] zendframework/zf2#5802
- [x] zendframework/zf2#5804
- [x] remove ZF2 version bump once the git subtree split has happened (next zf2 minor release)

See ocramius/ProxyManager#140
