### PR TITLE
use hhvm explicitly when installing composer

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -6,7 +6,7 @@ if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ]; then
     sudo apt-get install hhvm-nightly
     hhvm --version
 
-    curl -sS https://getcomposer.org/installer | php
+    curl -sS https://getcomposer.org/installer | hhvm
     hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 composer.phar self-update
     hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 composer.phar update --prefer-source
     hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 composer.phar install --dev --prefer-source


### PR DESCRIPTION
followup to 957de8648d64d2d0a3777fec793b52c198d39c82
