### PR TITLE
Use `tests/Bootstrap.php` file for tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <phpunit
-    bootstrap="./vendor/autoload.php"
+    bootstrap="./tests/Bootstrap.php"
     colors="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"


### PR DESCRIPTION
Use `tests/Bootstrap.php` file instead of `vendor/autoload.php` for run tests
