### PR TITLE
#97: handle private properties of superclasses

### DIFF
--- a/src/ProxyManager/ProxyGenerator/AccessInterceptor/MethodGenerator/MagicWakeup.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptor/MethodGenerator/MagicWakeup.php
@@ -19,6 +19,7 @@
 namespace ProxyManager\ProxyGenerator\AccessInterceptor\MethodGenerator;
 
 use ProxyManager\Generator\MagicMethodGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -39,13 +40,12 @@ class MagicWakeup extends MagicMethodGenerator
     {
         parent::__construct($originalClass, '__wakeup');
 
-        /* @var $publicProperties \ReflectionProperty[] */
-        $publicProperties = $originalClass->getProperties(ReflectionProperty::IS_PUBLIC);
-        $unsetProperties  = [];
-
-        foreach ($publicProperties as $publicProperty) {
-            $unsetProperties[] = '$this->' . $publicProperty->getName();
-        }
+        $unsetProperties = array_map(
+            function (ReflectionProperty $property) {
+                return '$this->' . $property->getName();
+            },
+            Properties::fromReflectionClass($originalClass)->getPublicProperties()
+        );
 
         $this->setBody($unsetProperties ? 'unset(' . implode(', ', $unsetProperties) . ");" : '');
     }

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyProperties.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyProperties.php
@@ -64,6 +64,10 @@ class BindProxyProperties extends MethodGenerator
         foreach ($originalClass->getProperties() as $originalProperty) {
             $propertyName = $originalProperty->getName();
 
+            if ($originalProperty->isStatic()) {
+                continue;
+            }
+
             if ($originalProperty->isPrivate()) {
                 $localizedProperties[] = "\\Closure::bind(function () use (\$localizedObject) {\n    "
                     . '$this->' . $propertyName . ' = & $localizedObject->' . $propertyName . ";\n"

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyProperties.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyProperties.php
@@ -64,6 +64,12 @@ class BindProxyProperties extends MethodGenerator
 
         $properties = Properties::fromReflectionClass($originalClass);
 
+        foreach ($properties->getAccessibleProperties() as $property) {
+            $propertyName = $property->getName();
+
+            $localizedProperties[] = '$this->' . $propertyName . ' = & $localizedObject->' . $propertyName . ";";
+        }
+
         foreach ($properties->getPrivateProperties() as $property) {
             $propertyName = $property->getName();
 
@@ -71,12 +77,6 @@ class BindProxyProperties extends MethodGenerator
                 . '$this->' . $propertyName . ' = & $localizedObject->' . $propertyName . ";\n"
                 . '}, $this, ' . var_export($property->getDeclaringClass()->getName(), true)
                 . ')->__invoke();';
-        }
-
-        foreach ($properties->getAccessibleProperties() as $property) {
-            $propertyName = $property->getName();
-
-            $localizedProperties[] = '$this->' . $propertyName . ' = & $localizedObject->' . $propertyName . ";";
         }
 
         $this->setDocblock(

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyProperties.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyProperties.php
@@ -44,21 +44,20 @@ class BindProxyProperties extends MethodGenerator
         PropertyGenerator $prefixInterceptors,
         PropertyGenerator $suffixInterceptors
     ) {
-        parent::__construct('bindProxyProperties', [], static::FLAG_PRIVATE);
-
-        $localizedObject = new ParameterGenerator('localizedObject');
-        $prefix          = new ParameterGenerator('prefixInterceptors');
-        $suffix          = new ParameterGenerator('suffixInterceptors');
-
-        $localizedObject->setType($originalClass->getName());
-        $prefix->setDefaultValue([]);
-        $suffix->setDefaultValue([]);
-        $prefix->setType('array');
-        $suffix->setType('array');
-
-        $this->setParameter($localizedObject);
-        $this->setParameter($prefix);
-        $this->setParameter($suffix);
+        parent::__construct(
+            'bindProxyProperties',
+            [
+                new ParameterGenerator('localizedObject', $originalClass->getName()),
+                new ParameterGenerator('prefixInterceptors', 'array', []),
+                new ParameterGenerator('suffixInterceptors', 'array', []),
+            ],
+            static::FLAG_PRIVATE,
+            null,
+            "@override constructor to setup interceptors\n\n"
+            . "@param \\" . $originalClass->getName() . " \$localizedObject\n"
+            . "@param \\Closure[] \$prefixInterceptors method interceptors to be used before method logic\n"
+            . "@param \\Closure[] \$suffixInterceptors method interceptors to be used before method logic"
+        );
 
         $localizedProperties = [];
 
@@ -79,12 +78,6 @@ class BindProxyProperties extends MethodGenerator
                 . ')->__invoke();';
         }
 
-        $this->setDocblock(
-            "@override constructor to setup interceptors\n\n"
-            . "@param \\" . $originalClass->getName() . " \$localizedObject\n"
-            . "@param \\Closure[] \$prefixInterceptors method interceptors to be used before method logic\n"
-            . "@param \\Closure[] \$suffixInterceptors method interceptors to be used before method logic"
-        );
         $this->setBody(
             (empty($localizedProperties) ? '' : implode("\n\n", $localizedProperties) . "\n\n")
             . '$this->' . $prefixInterceptors->getName() . " = \$prefixInterceptors;\n"

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyProperties.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyProperties.php
@@ -73,8 +73,7 @@ class BindProxyProperties extends MethodGenerator
                 . ')->__invoke();';
         }
 
-        /* @var $property \ReflectionProperty */
-        foreach (array_merge($properties->getPublicProperties(), $properties->getProtectedProperties()) as $property) {
+        foreach ($properties->getAccessibleProperties() as $property) {
             $propertyName = $property->getName();
 
             $localizedProperties[] = '$this->' . $propertyName . ' = & $localizedObject->' . $propertyName . ";";

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/StaticProxyConstructor.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/StaticProxyConstructor.php
@@ -20,6 +20,7 @@ namespace ProxyManager\ProxyGenerator\AccessInterceptorValueHolder\MethodGenerat
 
 use ProxyManager\Generator\MethodGenerator;
 use ProxyManager\Generator\ParameterGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ReflectionClass;
 use ReflectionProperty;
 use Zend\Code\Generator\PropertyGenerator;
@@ -60,8 +61,7 @@ class StaticProxyConstructor extends MethodGenerator
         $this->setParameter($prefix);
         $this->setParameter($suffix);
 
-        /* @var $publicProperties \ReflectionProperty[] */
-        $publicProperties = $originalClass->getProperties(ReflectionProperty::IS_PUBLIC);
+        $publicProperties = Properties::fromReflectionClass($originalClass)->getPublicProperties();
         $unsetProperties  = [];
 
         foreach ($publicProperties as $publicProperty) {

--- a/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/StaticProxyConstructor.php
+++ b/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/StaticProxyConstructor.php
@@ -19,6 +19,7 @@
 namespace ProxyManager\ProxyGenerator\NullObject\MethodGenerator;
 
 use ProxyManager\Generator\MethodGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ReflectionClass;
 use ReflectionProperty;
 
@@ -43,7 +44,7 @@ class StaticProxyConstructor extends MethodGenerator
             function (ReflectionProperty $publicProperty) {
                 return '$instance->' . $publicProperty->getName() . ' = null;';
             },
-            $this->getInstancePublicProperties($originalClass)
+            Properties::fromReflectionClass($originalClass)->getPublicProperties()
         );
 
         $this->setDocblock("Constructor for null object initialization");
@@ -53,21 +54,6 @@ class StaticProxyConstructor extends MethodGenerator
             . '$instance = (new \ReflectionClass(get_class()))->newInstanceWithoutConstructor();' . "\n\n"
             . ($nullableProperties ? implode("\n", $nullableProperties) . "\n\n" : '')
             . 'return $instance;'
-        );
-    }
-
-    /**
-     * @param ReflectionClass $originalClass
-     *
-     * @return ReflectionProperty[]
-     */
-    private function getInstancePublicProperties(ReflectionClass $originalClass)
-    {
-        return array_filter(
-            $originalClass->getProperties(ReflectionProperty::IS_PUBLIC),
-            function (ReflectionProperty $property) {
-                return ! $property->isStatic();
-            }
         );
     }
 }

--- a/src/ProxyManager/ProxyGenerator/PropertyGenerator/PublicPropertiesMap.php
+++ b/src/ProxyManager/ProxyGenerator/PropertyGenerator/PublicPropertiesMap.php
@@ -19,6 +19,7 @@
 namespace ProxyManager\ProxyGenerator\PropertyGenerator;
 
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ReflectionClass;
 use ReflectionProperty;
 use Zend\Code\Generator\PropertyGenerator;
@@ -43,7 +44,7 @@ class PublicPropertiesMap extends PropertyGenerator
     {
         parent::__construct(UniqueIdentifierGenerator::getIdentifier('publicProperties'));
 
-        foreach ($originalClass->getProperties(ReflectionProperty::IS_PUBLIC) as $publicProperty) {
+        foreach (Properties::fromReflectionClass($originalClass)->getPublicProperties() as $publicProperty) {
             $this->publicProperties[$publicProperty->getName()] = true;
         }
 

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/StaticProxyConstructor.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/StaticProxyConstructor.php
@@ -21,6 +21,7 @@ namespace ProxyManager\ProxyGenerator\RemoteObject\MethodGenerator;
 use ProxyManager\Factory\RemoteObject\AdapterInterface;
 use ProxyManager\Generator\MethodGenerator;
 use ProxyManager\Generator\ParameterGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ReflectionClass;
 use Zend\Code\Generator\PropertyGenerator;
 
@@ -61,10 +62,8 @@ class StaticProxyConstructor extends MethodGenerator
             . '$instance = (new \ReflectionClass(get_class()))->newInstanceWithoutConstructor();' . "\n\n"
             . '$instance->' . $adapterName . ' = $' . $adapterName . ';';
 
-        foreach ($originalClass->getProperties() as $property) {
-            if ($property->isPublic() && ! $property->isStatic()) {
-                $body .= "\nunset(\$instance->" . $property->getName() . ');';
-            }
+        foreach (Properties::fromReflectionClass($originalClass)->getPublicProperties() as $property) {
+            $body .= "\nunset(\$instance->" . $property->getName() . ');';
         }
 
         $this->setBody($body . "\n\nreturn \$instance;");

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/StaticProxyConstructor.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/StaticProxyConstructor.php
@@ -42,17 +42,13 @@ class StaticProxyConstructor extends MethodGenerator
      */
     public function __construct(ReflectionClass $originalClass, PropertyGenerator $adapter)
     {
-        parent::__construct(
-            'staticProxyConstructor',
-            [],
-            MethodGenerator::FLAG_PUBLIC | MethodGenerator::FLAG_STATIC
-        );
-
         $adapterName = $adapter->getName();
 
-        $this->setParameter(new ParameterGenerator($adapterName, AdapterInterface::class));
-
-        $this->setDocblock(
+        parent::__construct(
+            'staticProxyConstructor',
+            [new ParameterGenerator($adapterName, AdapterInterface::class)],
+            MethodGenerator::FLAG_PUBLIC | MethodGenerator::FLAG_STATIC,
+            null,
             'Constructor for remote object control\n\n'
             . '@param \\ProxyManager\\Factory\\RemoteObject\\AdapterInterface \$adapter'
         );

--- a/src/ProxyManager/ProxyGenerator/Util/Properties.php
+++ b/src/ProxyManager/ProxyGenerator/Util/Properties.php
@@ -142,4 +142,12 @@ final class Properties
 
         return $propertiesMap;
     }
+
+    /**
+     * @return ReflectionProperty[] indexed by the property internal visibility-aware name (\0*\0propertyName)
+     */
+    public function getInstanceProperties()
+    {
+        return array_merge($this->getAccessibleProperties(), $this->getPrivateProperties());
+    }
 }

--- a/src/ProxyManager/ProxyGenerator/ValueHolder/MethodGenerator/Constructor.php
+++ b/src/ProxyManager/ProxyGenerator/ValueHolder/MethodGenerator/Constructor.php
@@ -20,6 +20,7 @@ namespace ProxyManager\ProxyGenerator\ValueHolder\MethodGenerator;
 
 use ProxyManager\Generator\MethodGenerator;
 use ProxyManager\Generator\ParameterGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ReflectionClass;
 use ReflectionProperty;
 use Zend\Code\Generator\PropertyGenerator;
@@ -88,7 +89,7 @@ class Constructor extends MethodGenerator
                 function (ReflectionProperty $unsetProperty) {
                     return 'unset($this->' . $unsetProperty->getName() . ');';
                 },
-                $class->getProperties(ReflectionProperty::IS_PUBLIC)
+                Properties::fromReflectionClass($class)->getPublicProperties()
             )
         );
 

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
@@ -25,6 +25,7 @@ use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\AccessInterceptorInterface;
 use ProxyManager\ProxyGenerator\AccessInterceptorScopeLocalizerGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ProxyManagerTestAsset\BaseClass;
 use ProxyManagerTestAsset\ClassWithCounterConstructor;
 use ProxyManagerTestAsset\ClassWithPublicArrayProperty;
@@ -387,7 +388,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
     {
         $reflectionClass = new ReflectionClass($instance);
 
-        foreach ($reflectionClass->getProperties() as $property) {
+        foreach (Properties::fromReflectionClass($reflectionClass)->getInstanceProperties() as $property) {
             $property->setAccessible(true);
 
             $this->assertSame(

--- a/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
@@ -665,7 +665,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
             $initializer     = null;
             $reflectionClass = new ReflectionClass($realInstance);
 
-            foreach ($reflectionClass->getProperties() as $property) {
+            foreach (Properties::fromReflectionClass($reflectionClass)->getInstanceProperties() as $property) {
                 $property->setAccessible(true);
                 $property->setValue($proxy, $property->getValue($realInstance));
             }

--- a/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
@@ -27,6 +27,7 @@ use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ProxyManager\ProxyGenerator\LazyLoadingGhostGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ProxyManagerTestAsset\BaseClass;
 use ProxyManagerTestAsset\ClassWithCollidingPrivateInheritedProperties;
 use ProxyManagerTestAsset\ClassWithCounterConstructor;
@@ -573,7 +574,9 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
             }
         );
 
-        foreach ((new ReflectionClass(ClassWithMixedProperties::class))->getProperties() as $property) {
+        $reflectionClass = new ReflectionClass(ClassWithMixedProperties::class);
+
+        foreach (Properties::fromReflectionClass($reflectionClass)->getInstanceProperties() as $property) {
             $property->setAccessible(true);
 
             $this->assertSame(str_replace('Property', '', $property->getName()), $property->getValue($proxy));

--- a/tests/ProxyManagerTest/Functional/LazyLoadingGhostPerformanceTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingGhostPerformanceTest.php
@@ -23,6 +23,7 @@ use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\GhostObjectInterface;
 use ProxyManager\ProxyGenerator\LazyLoadingGhostGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ProxyManagerTestAsset\BaseClass;
 use ReflectionClass;
 use stdClass;
@@ -128,7 +129,7 @@ class LazyLoadingGhostPerformanceTest extends BaseLazyLoadingPerformanceTest
             $reflectionProperties = [];
             $reflectionClass      = new ReflectionClass($testedClass[0]);
 
-            foreach ($reflectionClass->getProperties() as $property) {
+            foreach (Properties::fromReflectionClass($reflectionClass)->getInstanceProperties() as $property) {
                 $property->setAccessible(true);
 
                 $reflectionProperties[$property->getName()] = $property;

--- a/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
+++ b/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
@@ -71,8 +71,7 @@ class MultipleProxyGenerationTest extends PHPUnit_Framework_TestCase
         $initializer                            = function () {
         };
 
-        $reflectionClass = new ReflectionClass($className);
-        $generated       = [
+        $generated = [
             $ghostProxyFactory->createProxy($className, $initializer),
             $virtualProxyFactory->createProxy($className, $initializer),
             $accessInterceptorFactory->createProxy(new $className()),

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyPropertiesTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyPropertiesTest.php
@@ -20,9 +20,9 @@ namespace ProxyManagerTest\ProxyGenerator\AccessInterceptorScopeLocalizer\Method
 
 use PHPUnit_Framework_TestCase;
 use ProxyManager\ProxyGenerator\AccessInterceptorScopeLocalizer\MethodGenerator\BindProxyProperties;
+use ProxyManagerTestAsset\ClassWithMixedProperties;
 use ProxyManagerTestAsset\ClassWithPrivateProperties;
 use ProxyManagerTestAsset\ClassWithProtectedProperties;
-use ProxyManagerTestAsset\ClassWithPublicProperties;
 use ReflectionClass;
 use Zend\Code\Generator\PropertyGenerator;
 
@@ -85,36 +85,42 @@ class BindProxyPropertiesTest extends PHPUnit_Framework_TestCase
     public function testBodyStructure()
     {
         $method = new BindProxyProperties(
-            new ReflectionClass(ClassWithPublicProperties::class),
+            new ReflectionClass(ClassWithMixedProperties::class),
             $this->prefixInterceptors,
             $this->suffixInterceptors
         );
 
-        $this->assertSame(
-            '$this->property0 = & $localizedObject->property0;
+        $expectedCode = <<<'PHP'
+$this->publicProperty0 = & $localizedObject->publicProperty0;
 
-$this->property1 = & $localizedObject->property1;
+$this->publicProperty1 = & $localizedObject->publicProperty1;
 
-$this->property2 = & $localizedObject->property2;
+$this->publicProperty2 = & $localizedObject->publicProperty2;
 
-$this->property3 = & $localizedObject->property3;
+$this->protectedProperty0 = & $localizedObject->protectedProperty0;
 
-$this->property4 = & $localizedObject->property4;
+$this->protectedProperty1 = & $localizedObject->protectedProperty1;
 
-$this->property5 = & $localizedObject->property5;
+$this->protectedProperty2 = & $localizedObject->protectedProperty2;
 
-$this->property6 = & $localizedObject->property6;
+\Closure::bind(function () use ($localizedObject) {
+    $this->privateProperty0 = & $localizedObject->privateProperty0;
+}, $this, 'ProxyManagerTestAsset\\ClassWithMixedProperties')->__invoke();
 
-$this->property7 = & $localizedObject->property7;
+\Closure::bind(function () use ($localizedObject) {
+    $this->privateProperty1 = & $localizedObject->privateProperty1;
+}, $this, 'ProxyManagerTestAsset\\ClassWithMixedProperties')->__invoke();
 
-$this->property8 = & $localizedObject->property8;
-
-$this->property9 = & $localizedObject->property9;
+\Closure::bind(function () use ($localizedObject) {
+    $this->privateProperty2 = & $localizedObject->privateProperty2;
+}, $this, 'ProxyManagerTestAsset\\ClassWithMixedProperties')->__invoke();
 
 $this->pre = $prefixInterceptors;
-$this->post = $suffixInterceptors;',
-            $method->getBody()
-        );
+$this->post = $suffixInterceptors;
+PHP;
+
+
+        $this->assertSame($expectedCode, $method->getBody());
     }
 
     public function testBodyStructureWithProtectedProperties()

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
@@ -24,6 +24,7 @@ use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\NullObjectInterface;
 use ProxyManager\ProxyGenerator\NullObjectGenerator;
+use ProxyManager\ProxyGenerator\Util\Properties;
 use ProxyManagerTestAsset\BaseClass;
 use ProxyManagerTestAsset\BaseInterface;
 use ProxyManagerTestAsset\ClassWithByRefMagicMethods;
@@ -74,7 +75,7 @@ class NullObjectGeneratorTest extends PHPUnit_Framework_TestCase
 
         $proxyGenerated = $generatedClassName::staticProxyConstructor();
 
-        foreach ($generatedReflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+        foreach (Properties::fromReflectionClass($generatedReflection)->getPublicProperties() as $property) {
             $this->assertNull($proxyGenerated->$property);
         }
 

--- a/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/PublicPropertiesMapTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/PublicPropertiesMapTest.php
@@ -20,6 +20,7 @@ namespace ProxyManagerTest\ProxyGenerator;
 
 use PHPUnit_Framework_TestCase;
 use ProxyManager\ProxyGenerator\PropertyGenerator\PublicPropertiesMap;
+use ProxyManagerTestAsset\ClassWithMixedProperties;
 use ProxyManagerTestAsset\ClassWithPublicProperties;
 use ProxyManagerTestAsset\EmptyClass;
 use ReflectionClass;
@@ -57,5 +58,14 @@ class PublicPropertiesMapTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($publicProperties->isStatic());
         $this->assertSame('private', $publicProperties->getVisibility());
         $this->assertFalse($publicProperties->isEmpty());
+    }
+
+    public function testClassWithMixedProperties()
+    {
+        $publicProperties = new PublicPropertiesMap(
+            new ReflectionClass(ClassWithMixedProperties::class)
+        );
+
+        $this->assertCount(3, $publicProperties->getDefaultValue()->getValue());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PropertiesTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PropertiesTest.php
@@ -186,4 +186,13 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf(ReflectionProperty::class, $group2['property8']);
         $this->assertInstanceOf(ReflectionProperty::class, $group2['property9']);
     }
+
+    public function testGetInstanceProperties()
+    {
+        $properties = Properties::fromReflectionClass(
+            new ReflectionClass(ClassWithMixedProperties::class)
+        );
+
+        $this->assertCount(9, $properties->getInstanceProperties());
+    }
 }

--- a/tests/ProxyManagerTestAsset/ClassWithMixedProperties.php
+++ b/tests/ProxyManagerTestAsset/ClassWithMixedProperties.php
@@ -26,6 +26,12 @@ namespace ProxyManagerTestAsset;
  */
 class ClassWithMixedProperties
 {
+    public static $publicStaticProperty       = 'publicStaticProperty';
+
+    protected static $protectedStaticProperty = 'protectedStaticProperty';
+
+    private static $privateStaticProperty     = 'privateStaticProperty';
+
     public $publicProperty0       = 'publicProperty0';
 
     public $publicProperty1       = 'publicProperty1';


### PR DESCRIPTION
This PR introduces fixes required to correctly handle private properties of complex class hierarchies, and also fixes minor bugs where static properties were included in generated code 

See #97