### PR TITLE
Cleanup: run codegen smoke-tests in same process

### DIFF
--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -40,28 +40,6 @@ use ReflectionClass;
  */
 class FatalPreventionFunctionalTest extends PHPUnit_Framework_TestCase
 {
-    private $template = <<<'PHP'
-require_once %s;
-
-$className               = %s;
-$generatedClass          = new ProxyManager\Generator\ClassGenerator(uniqid('generated'));
-$generatorStrategy       = new ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy();
-$classGenerator          = new %s;
-$classSignatureGenerator = new ProxyManager\Signature\ClassSignatureGenerator(
-    new ProxyManager\Signature\SignatureGenerator()
-);
-
-try {
-    $classGenerator->generate(new ReflectionClass($className), $generatedClass);
-    $classSignatureGenerator->addSignature($generatedClass, array('eval tests'));
-    $generatorStrategy->generate($generatedClass);
-} catch (ProxyManager\Exception\ExceptionInterface $e) {
-} catch (ReflectionException $e) {
-}
-
-echo 'SUCCESS: ' . %s;
-PHP;
-
     /**
      * Verifies that code generation and evaluation will not cause fatals with any given class
      *

--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -85,21 +85,23 @@ PHP;
             var_export($className, true)
         );
 
-        ob_start();
-        eval($code);
-        $result = ob_get_clean();
+        $generatedClass          = new \ProxyManager\Generator\ClassGenerator(uniqid('generated'));
+        $generatorStrategy       = new \ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy();
+        /* @var $classGenerator \ProxyManager\ProxyGenerator\ProxyGeneratorInterface */
+        $classGenerator          = new $generatorClass;
+        $classSignatureGenerator = new \ProxyManager\Signature\ClassSignatureGenerator(
+            new \ProxyManager\Signature\SignatureGenerator()
+        );
 
-        if (('SUCCESS: ' . $className) !== $result) {
-            $this->fail(sprintf(
-                "Crashed with class '%s' and generator '%s'.\n\nResult:\n%s\n\nGenerated code:\n%s'",
-                $generatorClass,
-                $className,
-                $result,
-                $code
-            ));
+        try {
+            $classGenerator->generate(new ReflectionClass($className), $generatedClass);
+            $classSignatureGenerator->addSignature($generatedClass, array('eval tests'));
+            $generatorStrategy->generate($generatedClass);
+        } catch (\ProxyManager\Exception\ExceptionInterface $e) {
+        } catch (\ReflectionException $e) {
         }
 
-        $this->assertSame('SUCCESS: ' . $className, $result);
+        $this->assertTrue(true, 'Code generation succeeded: proxy is valid or couldn\'t be generated at all');
     }
 
     /**

--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -73,14 +73,6 @@ PHP;
      */
     public function testCodeGeneration($generatorClass, $className)
     {
-        $code = sprintf(
-            $this->template,
-            var_export(realpath(__DIR__ . '/../../../vendor/autoload.php'), true),
-            var_export($className, true),
-            $generatorClass,
-            var_export($className, true)
-        );
-
         $generatedClass          = new \ProxyManager\Generator\ClassGenerator(uniqid('generated'));
         $generatorStrategy       = new \ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy();
         /* @var $classGenerator \ProxyManager\ProxyGenerator\ProxyGeneratorInterface */

--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -73,10 +73,6 @@ PHP;
      */
     public function testCodeGeneration($generatorClass, $className)
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('HHVM is just too slow for this kind of test right now.');
-        }
-
         $code = sprintf(
             $this->template,
             var_export(realpath(__DIR__ . '/../../../vendor/autoload.php'), true),

--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -155,6 +155,10 @@ PHP;
                     return false;
                 }
 
+                if ($reflectionClass->implementsInterface(ProxyInterface::class)) {
+                    return false;
+                }
+
                 $realPath = realpath($fileName);
 
                 foreach ($skippedPaths as $skippedPath) {


### PR DESCRIPTION
Simplifies the `FatalPreventionFunctionalTest` so that all tests run in the same process (major performance issue for running tests in HHVM)