### PR TITLE
#224 - GhostObjects can simply ignore scope checks during lazy-loading (temporarily fixes #210)

### DIFF
--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
@@ -41,7 +41,7 @@ class MagicGet extends MagicMethodGenerator
      * @var string
      */
     private $callParentTemplate =  <<<'PHP'
-%s
+$this->%s && ! $this->%s && $this->%s('__get', array('name' => $name));
 
 if (isset(self::$%s[$name])) {
     return $this->$name;
@@ -137,8 +137,9 @@ PHP;
 
         $this->setBody(sprintf(
             $this->callParentTemplate,
-            '$this->' . $initializerProperty->getName() . ' && $this->' . $callInitializer->getName()
-            . '(\'__get\', array(\'name\' => $name));',
+            $initializerProperty->getName(),
+            $initializationTracker->getName(),
+            $callInitializer->getName(),
             $publicProperties->getName(),
             $protectedProperties->getName(),
             $initializationTracker->getName(),

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
@@ -48,13 +48,17 @@ if (isset(self::$%s[$name])) {
 }
 
 if (isset(self::$%s[$name])) {
+    if ($this->%s) {
+        return $this->$name;
+    }
+
     // check protected property access via compatible class
     $callers      = debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
     $caller       = isset($callers[1]) ? $callers[1] : [];
     $object       = isset($caller['object']) ? $caller['object'] : '';
     $expectedType = self::$%s[$name];
 
-    if ($this->%s || $object instanceof $expectedType) {
+    if ($object instanceof $expectedType) {
         return $this->$name;
     }
 
@@ -137,8 +141,8 @@ PHP;
             . '(\'__get\', array(\'name\' => $name));',
             $publicProperties->getName(),
             $protectedProperties->getName(),
-            $protectedProperties->getName(),
             $initializationTracker->getName(),
+            $protectedProperties->getName(),
             $privateProperties->getName(),
             $privateProperties->getName(),
             $initializationTracker->getName(),

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
@@ -96,7 +96,8 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
                         $init,
                         $publicProperties,
                         $protectedProperties,
-                        $privateProperties
+                        $privateProperties,
+                        $initializationTracker
                     ),
                     new MagicSet(
                         $originalClass,

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
@@ -81,13 +81,17 @@ if (isset(self::$bar[$name])) {
 }
 
 if (isset(self::$baz[$name])) {
+    if ($this->init) {
+        return $this->$name;
+    }
+
     // check protected property access via compatible class
     $callers      = debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
     $caller       = isset($callers[1]) ? $callers[1] : [];
     $object       = isset($caller['object']) ? $caller['object'] : '';
     $expectedType = self::$baz[$name];
 
-    if ($this->init || $object instanceof $expectedType) {
+    if ($object instanceof $expectedType) {
         return $this->$name;
     }
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
@@ -74,7 +74,7 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
      * @var string
      */
     private $expectedCode = <<<'PHP'
-$this->foo && $this->baz('__get', array('name' => $name));
+$this->foo && ! $this->init && $this->baz('__get', array('name' => $name));
 
 if (isset(self::$bar[$name])) {
     return $this->$name;


### PR DESCRIPTION
See #224
See #210
