### PR TITLE
Don't suggest package that is already required.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     },
     "suggest": {
         "php": ">5.6 if you work with internal PHP classes, as reflection instantiation does not work with older PHP versions",
-        "zendframework/zend-stdlib":   "To use the hydrator proxy",
         "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
         "zendframework/zend-xmlrpc":   "To have the XmlRpc adapter (Remote Object feature)",
         "zendframework/zend-json":     "To have the JsonRpc adapter (Remote Object feature)",


### PR DESCRIPTION
The zendframework/zend-code dependency already installs zendframework/zend-stdlib. There is thus no need to suggest it as extra library.