### PR TITLE
Limited requirement of zend-code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php":                     ">=5.3.3",
-        "zendframework/zend-code": ">2.2.5,<3.0"
+        "zendframework/zend-code": ">2.2.5,<2.5.2"
     },
     "require-dev": {
         "ext-phar":                    "*",


### PR DESCRIPTION
zend-code:2.5.2 bumps the PHP requirement to >= 5.5. Not advisable on a stable version.

Fixes this by limiting the requirement to the last minor that required 5.3.