### PR TITLE
Hotfix - #249 file writer generator strategy rename failures (2.0.x rebase)

### DIFF
--- a/src/ProxyManager/Exception/FileNotWritableException.php
+++ b/src/ProxyManager/Exception/FileNotWritableException.php
@@ -54,7 +54,7 @@ class FileNotWritableException extends UnexpectedValueException implements Excep
      */
     public static function fromNonWritableLocation($path)
     {
-        $messages = [];
+        $messages = array();
 
         if (($destination = realpath($path)) && ! is_file($destination)) {
             $messages[] = 'exists and is not a file';

--- a/src/ProxyManager/Exception/FileNotWritableException.php
+++ b/src/ProxyManager/Exception/FileNotWritableException.php
@@ -54,7 +54,7 @@ class FileNotWritableException extends UnexpectedValueException implements Excep
      */
     public static function fromNonWritableLocation($path)
     {
-        $messages = array();
+        $messages = [];
 
         if (($destination = realpath($path)) && ! is_file($destination)) {
             $messages[] = 'exists and is not a file';

--- a/src/ProxyManager/Exception/FileNotWritableException.php
+++ b/src/ProxyManager/Exception/FileNotWritableException.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ProxyManager\Exception;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use ReflectionMethod;
+use UnexpectedValueException;
+
+/**
+ * Exception for non writable files
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @license MIT
+ */
+class FileNotWritableException extends UnexpectedValueException implements ExceptionInterface
+{
+    /**
+     * @param string $fromPath
+     * @param string $toPath
+     *
+     * @return self
+     */
+    public static function fromInvalidMoveOperation($fromPath, $toPath)
+    {
+        return new self(sprintf(
+            'Could not move file "%s" to location "%s": '
+            . 'either the source file is not readable, or the destination is not writable',
+            $fromPath,
+            $toPath
+        ));
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return self
+     */
+    public static function fromNonWritableLocation($path)
+    {
+        $messages = [];
+
+        if (($destination = realpath($path)) && ! is_file($destination)) {
+            $messages[] = 'exists and is not a file';
+        }
+
+        if (! is_writable($destination)) {
+            $messages[] = 'is not writable';
+        }
+
+        return new self(sprintf('Could not write to path "%s": %s', $path, implode(', ', $messages)));
+    }
+}

--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -69,12 +69,10 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
         try {
             $this->writeFile("<?php\n\n" . $generatedCode, $fileName);
         } catch (FileNotWritableException $fileNotWritable) {
-            restore_error_handler();
-
             throw $fileNotWritable;
+        } finally {
+            restore_error_handler();
         }
-
-        restore_error_handler();
 
         return $generatedCode;
     }

--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -97,6 +97,8 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
         }
 
         if (! rename($tmpFileName, $location)) {
+            unlink($tmpFileName);
+
             throw FileNotWritableException::fromInvalidMoveOperation($tmpFileName, $location);
         }
     }

--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -18,6 +18,7 @@
 
 namespace ProxyManager\GeneratorStrategy;
 
+use ProxyManager\Exception\FileNotWritableException;
 use ProxyManager\FileLocator\FileLocatorInterface;
 use Zend\Code\Generator\ClassGenerator;
 
@@ -37,11 +38,18 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
     protected $fileLocator;
 
     /**
+     * @var callable
+     */
+    private $emptyErrorHandler;
+
+    /**
      * @param \ProxyManager\FileLocator\FileLocatorInterface $fileLocator
      */
     public function __construct(FileLocatorInterface $fileLocator)
     {
-        $this->fileLocator = $fileLocator;
+        $this->fileLocator       = $fileLocator;
+        $this->emptyErrorHandler = function () {
+        };
     }
 
     /**
@@ -55,13 +63,41 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
             . '\\' . trim($classGenerator->getName(), '\\');
         $generatedCode = $classGenerator->generate();
         $fileName      = $this->fileLocator->getProxyFileName($className);
-        $tmpFileName   = $fileName . '.' . uniqid('', true);
 
-        // renaming files is necessary to avoid race conditions when the same file is written multiple times
-        // in a short time period
-        file_put_contents($tmpFileName, "<?php\n\n" . $generatedCode);
-        rename($tmpFileName, $fileName);
+        set_error_handler($this->emptyErrorHandler);
+
+        try {
+            $this->writeFile("<?php\n\n" . $generatedCode, $fileName);
+        } catch (FileNotWritableException $fileNotWritable) {
+            restore_error_handler();
+
+            throw $fileNotWritable;
+        }
+
+        restore_error_handler();
 
         return $generatedCode;
+    }
+
+    /**
+     * Writes the source file in such a way that race conditions are avoided when the same file is written
+     * multiple times in a short time period
+     *
+     * @param string $source
+     * @param string $location
+     *
+     * @throws FileNotWritableException
+     */
+    private function writeFile($source, $location)
+    {
+        $tmpFileName   = $location . '.' . uniqid('', true);
+
+        if (! file_put_contents($tmpFileName, $source)) {
+            throw FileNotWritableException::fromNonWritableLocation($tmpFileName);
+        }
+
+        if (! rename($tmpFileName, $location)) {
+            throw FileNotWritableException::fromInvalidMoveOperation($tmpFileName, $location);
+        }
     }
 }

--- a/tests/ProxyManagerTest/Exception/FileNotWritableExceptionTest.php
+++ b/tests/ProxyManagerTest/Exception/FileNotWritableExceptionTest.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ProxyManagerTest\Exception;
+
+use PHPUnit_Framework_TestCase;
+use ProxyManager\Exception\FileNotWritableException;
+
+/**
+ * Tests for {@see \ProxyManager\Exception\FileNotWritableException}
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @license MIT
+ *
+ * @covers \ProxyManager\Exception\FileNotWritableException
+ * @group Coverage
+ */
+class FileNotWritableExceptionTest extends PHPUnit_Framework_TestCase
+{
+    public function testFromInvalidMoveOperation()
+    {
+        $exception = FileNotWritableException::fromInvalidMoveOperation('/tmp/a', '/tmp/b');
+
+        $this->assertInstanceOf('ProxyManager\\Exception\\FileNotWritableException', $exception);
+        $this->assertSame(
+            'Could not move file "/tmp/a" to location "/tmp/b": either the source file is not readable,'
+            . ' or the destination is not writable',
+            $exception->getMessage()
+        );
+    }
+
+    public function testFromNotWritableLocationWithNonFilePath()
+    {
+        $exception = FileNotWritableException::fromNonWritableLocation(__DIR__);
+
+        $this->assertInstanceOf('ProxyManager\\Exception\\FileNotWritableException', $exception);
+        $this->assertSame(
+            'Could not write to path "' . __DIR__ . '": exists and is not a file',
+            $exception->getMessage()
+        );
+    }
+
+    public function testFromNotWritableLocationWithNonWritablePath()
+    {
+        $path = sys_get_temp_dir() . '/' . uniqid('FileNotWritableExceptionTestNonWritable', true);
+
+        mkdir($path, 0555);
+
+        $exception = FileNotWritableException::fromNonWritableLocation($path . '/foo');
+
+        $this->assertInstanceOf('ProxyManager\\Exception\\FileNotWritableException', $exception);
+        $this->assertSame(
+            'Could not write to path "' . $path . '/foo": is not writable',
+            $exception->getMessage()
+        );
+    }
+}

--- a/tests/ProxyManagerTest/Exception/FileNotWritableExceptionTest.php
+++ b/tests/ProxyManagerTest/Exception/FileNotWritableExceptionTest.php
@@ -36,7 +36,7 @@ class FileNotWritableExceptionTest extends PHPUnit_Framework_TestCase
     {
         $exception = FileNotWritableException::fromInvalidMoveOperation('/tmp/a', '/tmp/b');
 
-        $this->assertInstanceOf('ProxyManager\\Exception\\FileNotWritableException', $exception);
+        $this->assertInstanceOf(FileNotWritableException::class, $exception);
         $this->assertSame(
             'Could not move file "/tmp/a" to location "/tmp/b": either the source file is not readable,'
             . ' or the destination is not writable',
@@ -48,7 +48,7 @@ class FileNotWritableExceptionTest extends PHPUnit_Framework_TestCase
     {
         $exception = FileNotWritableException::fromNonWritableLocation(__DIR__);
 
-        $this->assertInstanceOf('ProxyManager\\Exception\\FileNotWritableException', $exception);
+        $this->assertInstanceOf(FileNotWritableException::class, $exception);
         $this->assertSame(
             'Could not write to path "' . __DIR__ . '": exists and is not a file',
             $exception->getMessage()
@@ -63,7 +63,7 @@ class FileNotWritableExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = FileNotWritableException::fromNonWritableLocation($path . '/foo');
 
-        $this->assertInstanceOf('ProxyManager\\Exception\\FileNotWritableException', $exception);
+        $this->assertInstanceOf(FileNotWritableException::class, $exception);
         $this->assertSame(
             'Could not write to path "' . $path . '/foo": is not writable',
             $exception->getMessage()

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -75,8 +75,8 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
 
         mkdir($tmpDirPath, 0555, true);
 
-        /* @var $locator \ProxyManager\FileLocator\FileLocatorInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $locator   = $this->getMock('ProxyManager\\FileLocator\\FileLocatorInterface');
+        /* @var $locator FileLocatorInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $locator   = $this->getMock(FileLocatorInterface::class);
         $generator = new FileWriterGeneratorStrategy($locator);
         $tmpFile   = $tmpDirPath . '/' . uniqid('FileWriterGeneratorStrategyFailedFileWriteTest', true) . '.php';
         $namespace = 'Foo';
@@ -89,14 +89,14 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
             ->with($fqcn)
             ->will($this->returnValue($tmpFile));
 
-        $this->setExpectedException('ProxyManager\\Exception\\FileNotWritableException');
+        $this->setExpectedException(FileNotWritableException::class);
         $generator->generate(new ClassGenerator($fqcn));
     }
 
     public function testGenerateWillFailIfTmpFileCannotBeMovedToFinalDestination()
     {
         /* @var $locator \ProxyManager\FileLocator\FileLocatorInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $locator   = $this->getMock('ProxyManager\\FileLocator\\FileLocatorInterface');
+        $locator   = $this->getMock(FileLocatorInterface::class);
         $generator = new FileWriterGeneratorStrategy($locator);
         $tmpFile   = sys_get_temp_dir() . '/' . uniqid('FileWriterGeneratorStrategyFailedFileMoveTest', true) . '.php';
         $namespace = 'Foo';
@@ -111,7 +111,7 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
 
         mkdir($tmpFile);
 
-        $this->setExpectedException('ProxyManager\\Exception\\FileNotWritableException');
+        $this->setExpectedException(FileNotWritableException::class);
         $generator->generate(new ClassGenerator($fqcn));
     }
 
@@ -121,8 +121,8 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
 
         mkdir($tmpDirPath);
 
-        /* @var $locator \ProxyManager\FileLocator\FileLocatorInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $locator   = $this->getMock('ProxyManager\\FileLocator\\FileLocatorInterface');
+        /* @var $locator FileLocatorInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $locator   = $this->getMock(FileLocatorInterface::class);
         $generator = new FileWriterGeneratorStrategy($locator);
         $tmpFile   = $tmpDirPath . '/' . uniqid('FileWriterGeneratorStrategyFailedFileMoveTest', true) . '.php';
         $namespace = 'Foo';

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -144,7 +144,7 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         } catch (FileNotWritableException $exception) {
             rmdir($tmpFile);
 
-            $this->assertEquals(['.', '..'], scandir($tmpDirPath));
+            $this->assertEquals(array('.', '..'), scandir($tmpDirPath));
         }
     }
 }

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -141,7 +141,7 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         } catch (FileNotWritableException $exception) {
             rmdir($tmpFile);
 
-            $this->assertEquals(array('.', '..'), scandir($tmpDirPath));
+            $this->assertEquals(['.', '..'], scandir($tmpDirPath));
         }
     }
 }

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -32,15 +32,12 @@ use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
  * @license MIT
  *
  * @group Coverage
+ * @covers \ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy
  *
  * Note: this test generates temporary files that are not deleted
  */
 class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
 {
-    /**
-     * @covers \ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy::__construct
-     * @covers \ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy::generate
-     */
     public function testGenerate()
     {
         /* @var $locator FileLocatorInterface|\PHPUnit_Framework_MockObject_MockObject */

--- a/tests/language-feature-scripts/remote-object-json-adapter-denies-unknow-method.phpt
+++ b/tests/language-feature-scripts/remote-object-json-adapter-denies-unknow-method.phpt
@@ -31,7 +31,7 @@ class Foo implements FooServiceInterface
 
 class CustomAdapter implements AdapterInterface
 {
-    public function call($wrappedClass, $method, array $params = array())
+    public function call($wrappedClass, $method, array $params = [])
     {
         return 'baz';
     }


### PR DESCRIPTION
This is a version of the hotfix for #249 (applied in #250) rebased for the `master` (`2.0.x`) branch.