### PR TITLE
Fix: Methods do not accept as many arguments as passed into them

### DIFF
--- a/src/ProxyManager/Factory/AbstractBaseFactory.php
+++ b/src/ProxyManager/Factory/AbstractBaseFactory.php
@@ -55,11 +55,10 @@ abstract class AbstractBaseFactory
      * Generate a proxy from a class name
      *
      * @param string  $className
-     * @param mixed[] $proxyOptions
      *
      * @return string proxy class name
      */
-    protected function generateProxy($className, array $proxyOptions = [])
+    protected function generateProxy($className)
     {
         if (isset($this->checkedClasses[$className])) {
             return $this->checkedClasses[$className];
@@ -79,8 +78,7 @@ abstract class AbstractBaseFactory
             $this->generateProxyClass(
                 $proxyClassName,
                 $className,
-                $proxyParameters,
-                $proxyOptions
+                $proxyParameters
             );
         }
 
@@ -103,11 +101,10 @@ abstract class AbstractBaseFactory
      * @param string  $proxyClassName
      * @param string  $className
      * @param array   $proxyParameters
-     * @param mixed[] $proxyOptions
      *
      * @return void
      */
-    private function generateProxyClass($proxyClassName, $className, array $proxyParameters, array $proxyOptions = [])
+    private function generateProxyClass($proxyClassName, $className, array $proxyParameters)
     {
         $className = $this->configuration->getClassNameInflector()->getUserClassName($className);
         $phpClass  = new ClassGenerator($proxyClassName);

--- a/src/ProxyManager/Factory/AbstractBaseFactory.php
+++ b/src/ProxyManager/Factory/AbstractBaseFactory.php
@@ -112,7 +112,7 @@ abstract class AbstractBaseFactory
         $className = $this->configuration->getClassNameInflector()->getUserClassName($className);
         $phpClass  = new ClassGenerator($proxyClassName);
 
-        $this->getGenerator()->generate(new ReflectionClass($className), $phpClass, $proxyOptions);
+        $this->getGenerator()->generate(new ReflectionClass($className), $phpClass);
 
         $phpClass = $this->configuration->getClassSignatureGenerator()->addSignature($phpClass, $proxyParameters);
 

--- a/src/ProxyManager/Factory/AbstractBaseFactory.php
+++ b/src/ProxyManager/Factory/AbstractBaseFactory.php
@@ -116,7 +116,7 @@ abstract class AbstractBaseFactory
 
         $phpClass = $this->configuration->getClassSignatureGenerator()->addSignature($phpClass, $proxyParameters);
 
-        $this->configuration->getGeneratorStrategy()->generate($phpClass, $proxyOptions);
+        $this->configuration->getGeneratorStrategy()->generate($phpClass);
 
         $autoloader = $this->configuration->getProxyAutoloader();
 


### PR DESCRIPTION
This PR

* [x] removes a method argument where a method accepts only two arguments, not three
* [x] removes a method argument where a method accepts only one argument, not two
* [x] removes an unused method argument `$proxyOptions`
