### PR TITLE
Fix: Use all the columns

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
     processIsolation="false"
     backupGlobals="false"
     syntaxCheck="true"
+    columns="max"
 >
     <testsuite name="ProxyManager tests">
         <directory>./tests/ProxyManagerTest</directory>


### PR DESCRIPTION
This PR

* [x] uses all the columns when running tests

## Before

```
$ vendor/bin/phpunit
PHPUnit 4.8.5 by Sebastian Bergmann and contributors.

Runtime:	PHP 5.6.12 with Xdebug 2.3.3
Configuration:	/Users/am/Sites/ocramius/ProxyManager/phpunit.xml.dist

.............................................................   61 / 1306 (  4%)
....S........................................................  122 / 1306 (  9%)
.......^C
```

## After

```
$ vendor/bin/phpunit
PHPUnit 4.8.5 by Sebastian Bergmann and contributors.

Runtime:	PHP 5.6.12 with Xdebug 2.3.3
Configuration:	/Users/am/Sites/ocramius/ProxyManager/phpunit.xml.dist

.................................................................S.......................................................................................................................................................................................................................................................................................  345 / 1306 ( 26%)
.................................................................................................................................................................^C
```