### PR TITLE
PHP 7.0.7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php":                       "~7.0",
+        "php":                       "7.0.0 - 7.0.5 || ^7.0.7",
         "zendframework/zend-code":   "~3.0",
         "ocramius/package-versions": "^1.0"
     },

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
@@ -63,7 +63,7 @@ DOCBLOCK;
                 new ParameterGenerator('methodName'),
                 new ParameterGenerator('parameters', 'array'),
             ],
-            static::VISIBILITY_PRIVATE,
+            static::FLAG_PRIVATE,
             null,
             $docblock
         );

--- a/src/ProxyManager/ProxyGenerator/Util/UnsetPropertiesGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/UnsetPropertiesGenerator.php
@@ -29,7 +29,7 @@ namespace ProxyManager\ProxyGenerator\Util;
 final class UnsetPropertiesGenerator
 {
     private static $closureTemplate = <<<'PHP'
-\Closure::bind(function (\%s $%s) {
+\Closure::bind(function (\%s $instance) {
     %s
 }, $%s, %s)->__invoke($%s);
 PHP;
@@ -86,8 +86,7 @@ PHP;
         return sprintf(
             self::$closureTemplate,
             $declaringClassName,
-            $instanceName,
-            self::generateUnsetStatement($properties, $instanceName),
+            self::generateUnsetStatement($properties, 'instance'),
             $instanceName,
             var_export($declaringClassName, true),
             $instanceName

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/MagicWakeupTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/MagicWakeupTest.php
@@ -72,8 +72,8 @@ class MagicWakeupTest extends PHPUnit_Framework_TestCase
             'unset($this->publicProperty0, $this->publicProperty1, $this->publicProperty2, '
             . '$this->protectedProperty0, $this->protectedProperty1, $this->protectedProperty2);
 
-\Closure::bind(function (\ProxyManagerTestAsset\ClassWithMixedProperties $this) {
-    unset($this->privateProperty0, $this->privateProperty1, $this->privateProperty2);
+\Closure::bind(function (\ProxyManagerTestAsset\ClassWithMixedProperties $instance) {
+    unset($instance->privateProperty0, $instance->privateProperty1, $instance->privateProperty2);
 }, $this, \'ProxyManagerTestAsset\\\\ClassWithMixedProperties\')->__invoke($this);
 
 ',

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/UnsetPropertiesGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/UnsetPropertiesGeneratorTest.php
@@ -72,8 +72,8 @@ class UnsetPropertiesGeneratorTest extends PHPUnit_Framework_TestCase
                 BaseClass::class,
                 'unset($foo->publicProperty, $foo->protectedProperty);
 
-\Closure::bind(function (\ProxyManagerTestAsset\BaseClass $foo) {
-    unset($foo->privateProperty);
+\Closure::bind(function (\ProxyManagerTestAsset\BaseClass $instance) {
+    unset($instance->privateProperty);
 }, $foo, \'ProxyManagerTestAsset\\\\BaseClass\')->__invoke($foo);
 
 ',
@@ -84,8 +84,8 @@ class UnsetPropertiesGeneratorTest extends PHPUnit_Framework_TestCase
                 'unset($foo->publicProperty0, $foo->publicProperty1, $foo->publicProperty2, $foo->protectedProperty0, '
                 . '$foo->protectedProperty1, $foo->protectedProperty2);
 
-\Closure::bind(function (\ProxyManagerTestAsset\ClassWithMixedProperties $foo) {
-    unset($foo->privateProperty0, $foo->privateProperty1, $foo->privateProperty2);
+\Closure::bind(function (\ProxyManagerTestAsset\ClassWithMixedProperties $instance) {
+    unset($instance->privateProperty0, $instance->privateProperty1, $instance->privateProperty2);
 }, $foo, \'ProxyManagerTestAsset\\\\ClassWithMixedProperties\')->__invoke($foo);
 
 ',
@@ -93,13 +93,15 @@ class UnsetPropertiesGeneratorTest extends PHPUnit_Framework_TestCase
             ],
             ClassWithCollidingPrivateInheritedProperties::class => [
                 ClassWithCollidingPrivateInheritedProperties::class,
-                '\Closure::bind(function (\ProxyManagerTestAsset\ClassWithCollidingPrivateInheritedProperties $bar) {
-    unset($bar->property0);
+                '\Closure::bind(function (\ProxyManagerTestAsset\ClassWithCollidingPrivateInheritedProperties '
+                . '$instance) {
+    unset($instance->property0);
 }, $bar, \'ProxyManagerTestAsset\\\\ClassWithCollidingPrivateInheritedProperties\')->__invoke($bar);
 
-\Closure::bind(function (\ProxyManagerTestAsset\ClassWithPrivateProperties $bar) {
-    unset($bar->property0, $bar->property1, $bar->property2, $bar->property3, $bar->property4, '
-                . '$bar->property5, $bar->property6, $bar->property7, $bar->property8, $bar->property9);
+\Closure::bind(function (\ProxyManagerTestAsset\ClassWithPrivateProperties $instance) {
+    unset($instance->property0, $instance->property1, $instance->property2, $instance->property3, '
+                . '$instance->property4, $instance->property5, $instance->property6, $instance->property7, '
+                . '$instance->property8, $instance->property9);
 }, $bar, \'ProxyManagerTestAsset\\\\ClassWithPrivateProperties\')->__invoke($bar);
 
 ',

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/ConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/ConstructorTest.php
@@ -115,8 +115,8 @@ if (! $this->foo) {
 unset($this->publicProperty0, $this->publicProperty1, $this->publicProperty2, $this->protectedProperty0, '
             . '$this->protectedProperty1, $this->protectedProperty2);
 
-\Closure::bind(function (\ProxyManagerTestAsset\ClassWithMixedProperties $this) {
-    unset($this->privateProperty0, $this->privateProperty1, $this->privateProperty2);
+\Closure::bind(function (\ProxyManagerTestAsset\ClassWithMixedProperties $instance) {
+    unset($instance->privateProperty0, $instance->privateProperty1, $instance->privateProperty2);
 }, $this, \'ProxyManagerTestAsset\\\\ClassWithMixedProperties\')->__invoke($this);
 
 }';
@@ -145,8 +145,8 @@ static $reflection;
 if (! $this->foo) {
     $reflection = $reflection ?: new \ReflectionClass('ProxyManagerTestAsset\\ClassWithVariadicConstructorArgument');
     $this->foo = $reflection->newInstanceWithoutConstructor();
-\Closure::bind(function (\ProxyManagerTestAsset\ClassWithVariadicConstructorArgument $this) {
-    unset($this->foo, $this->bar);
+\Closure::bind(function (\ProxyManagerTestAsset\ClassWithVariadicConstructorArgument $instance) {
+    unset($instance->foo, $instance->bar);
 }, $this, 'ProxyManagerTestAsset\\ClassWithVariadicConstructorArgument')->__invoke($this);
 
 }


### PR DESCRIPTION
Fixes #306 by providing compatibility with PHP 7.0.7, which includes a bugfix for https://bugs.php.net/bug.php?id=72174 (which caused ProxyManager to be not usable)