### PR TITLE
Cleanup: remove unused imports, deprecated method usage, static/non-static assertion mixup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     ],
     "require": {
         "php":                       "7.0.0 - 7.0.5 || ^7.0.7",
-        "zendframework/zend-code":   "~3.0",
+        "zendframework/zend-code":   "^3.0.2",
         "ocramius/package-versions": "^1.0"
     },
     "require-dev": {
         "ext-phar":                    "*",
-        "phpunit/phpunit":             "^5.1.3",
-        "squizlabs/php_codesniffer":   "^2.5.1",
+        "phpunit/phpunit":             "^5.3.4",
+        "squizlabs/php_codesniffer":   "^2.6.0",
         "couscous/couscous":           "^1.4.0"
     },
     "suggest": {

--- a/tests/ProxyManagerTest/Autoloader/AutoloaderTest.php
+++ b/tests/ProxyManagerTest/Autoloader/AutoloaderTest.php
@@ -70,12 +70,12 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
         $className = 'Foo\\' . UniqueIdentifierGenerator::getIdentifier('Bar');
         $this
             ->classNameInflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isProxyClassName')
             ->with($className)
-            ->will($this->returnValue(false));
+            ->will(self::returnValue(false));
 
-        $this->assertFalse($this->autoloader->__invoke($className));
+        self::assertFalse($this->autoloader->__invoke($className));
     }
 
     /**
@@ -86,17 +86,17 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
         $className = 'Foo\\' . UniqueIdentifierGenerator::getIdentifier('Bar');
         $this
             ->classNameInflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isProxyClassName')
             ->with($className)
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
         $this
             ->fileLocator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyFileName')
-            ->will($this->returnValue(__DIR__ . '/non-existing'));
+            ->will(self::returnValue(__DIR__ . '/non-existing'));
 
-        $this->assertFalse($this->autoloader->__invoke($className));
+        self::assertFalse($this->autoloader->__invoke($className));
     }
 
     /**
@@ -104,7 +104,7 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
      */
     public function testWillNotAutoloadExistingClass()
     {
-        $this->assertFalse($this->autoloader->__invoke(__CLASS__));
+        self::assertFalse($this->autoloader->__invoke(__CLASS__));
     }
 
     /**
@@ -121,17 +121,17 @@ class AutoloaderTest extends PHPUnit_Framework_TestCase
 
         $this
             ->classNameInflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('isProxyClassName')
             ->with($fqcn)
-            ->will($this->returnValue(true));
+            ->will(self::returnValue(true));
         $this
             ->fileLocator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyFileName')
-            ->will($this->returnValue($fileName));
+            ->will(self::returnValue($fileName));
 
-        $this->assertTrue($this->autoloader->__invoke($fqcn));
-        $this->assertTrue(class_exists($fqcn, false));
+        self::assertTrue($this->autoloader->__invoke($fqcn));
+        self::assertTrue(class_exists($fqcn, false));
     }
 }

--- a/tests/ProxyManagerTest/ConfigurationTest.php
+++ b/tests/ProxyManagerTest/ConfigurationTest.php
@@ -59,14 +59,14 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
      */
     public function testGetSetProxiesNamespace()
     {
-        $this->assertSame(
+        self::assertSame(
             'ProxyManagerGeneratedProxy',
             $this->configuration->getProxiesNamespace(),
             'Default setting check for BC'
         );
 
         $this->configuration->setProxiesNamespace('foo');
-        $this->assertSame('foo', $this->configuration->getProxiesNamespace());
+        self::assertSame('foo', $this->configuration->getProxiesNamespace());
     }
 
     /**
@@ -75,13 +75,13 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetGetClassNameInflector()
     {
-        $this->assertInstanceOf(ClassNameInflectorInterface::class, $this->configuration->getClassNameInflector());
+        self::assertInstanceOf(ClassNameInflectorInterface::class, $this->configuration->getClassNameInflector());
 
         /* @var $inflector \ProxyManager\Inflector\ClassNameInflectorInterface */
         $inflector = $this->getMock(ClassNameInflectorInterface::class);
 
         $this->configuration->setClassNameInflector($inflector);
-        $this->assertSame($inflector, $this->configuration->getClassNameInflector());
+        self::assertSame($inflector, $this->configuration->getClassNameInflector());
     }
 
     /**
@@ -89,7 +89,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
      */
     public function testDefaultGeneratorStrategyNeedToBeAInstanceOfEvaluatingGeneratorStrategy()
     {
-        $this->assertInstanceOf(EvaluatingGeneratorStrategy::class, $this->configuration->getGeneratorStrategy());
+        self::assertInstanceOf(EvaluatingGeneratorStrategy::class, $this->configuration->getGeneratorStrategy());
     }
 
     /**
@@ -99,13 +99,13 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
     public function testSetGetGeneratorStrategy()
     {
 
-        $this->assertInstanceOf(GeneratorStrategyInterface::class, $this->configuration->getGeneratorStrategy());
+        self::assertInstanceOf(GeneratorStrategyInterface::class, $this->configuration->getGeneratorStrategy());
 
         /* @var $strategy \ProxyManager\GeneratorStrategy\GeneratorStrategyInterface */
         $strategy = $this->getMock(GeneratorStrategyInterface::class);
 
         $this->configuration->setGeneratorStrategy($strategy);
-        $this->assertSame($strategy, $this->configuration->getGeneratorStrategy());
+        self::assertSame($strategy, $this->configuration->getGeneratorStrategy());
     }
 
     /**
@@ -114,10 +114,10 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetGetProxiesTargetDir()
     {
-        $this->assertTrue(is_dir($this->configuration->getProxiesTargetDir()));
+        self::assertTrue(is_dir($this->configuration->getProxiesTargetDir()));
 
         $this->configuration->setProxiesTargetDir(__DIR__);
-        $this->assertSame(__DIR__, $this->configuration->getProxiesTargetDir());
+        self::assertSame(__DIR__, $this->configuration->getProxiesTargetDir());
     }
 
     /**
@@ -126,13 +126,13 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetGetProxyAutoloader()
     {
-        $this->assertInstanceOf(AutoloaderInterface::class, $this->configuration->getProxyAutoloader());
+        self::assertInstanceOf(AutoloaderInterface::class, $this->configuration->getProxyAutoloader());
 
         /* @var $autoloader \ProxyManager\Autoloader\AutoloaderInterface */
         $autoloader = $this->getMock(AutoloaderInterface::class);
 
         $this->configuration->setProxyAutoloader($autoloader);
-        $this->assertSame($autoloader, $this->configuration->getProxyAutoloader());
+        self::assertSame($autoloader, $this->configuration->getProxyAutoloader());
     }
 
     /**
@@ -141,13 +141,13 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetGetSignatureGenerator()
     {
-        $this->assertInstanceOf(SignatureGeneratorInterface::class, $this->configuration->getSignatureGenerator());
+        self::assertInstanceOf(SignatureGeneratorInterface::class, $this->configuration->getSignatureGenerator());
 
         /* @var $signatureGenerator \ProxyManager\Signature\SignatureGeneratorInterface */
         $signatureGenerator = $this->getMock(SignatureGeneratorInterface::class);
 
         $this->configuration->setSignatureGenerator($signatureGenerator);
-        $this->assertSame($signatureGenerator, $this->configuration->getSignatureGenerator());
+        self::assertSame($signatureGenerator, $this->configuration->getSignatureGenerator());
     }
 
     /**
@@ -156,13 +156,13 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetGetSignatureChecker()
     {
-        $this->assertInstanceOf(SignatureCheckerInterface::class, $this->configuration->getSignatureChecker());
+        self::assertInstanceOf(SignatureCheckerInterface::class, $this->configuration->getSignatureChecker());
 
         /* @var $signatureChecker \ProxyManager\Signature\SignatureCheckerInterface */
         $signatureChecker = $this->getMock(SignatureCheckerInterface::class);
 
         $this->configuration->setSignatureChecker($signatureChecker);
-        $this->assertSame($signatureChecker, $this->configuration->getSignatureChecker());
+        self::assertSame($signatureChecker, $this->configuration->getSignatureChecker());
     }
 
     /**
@@ -171,7 +171,7 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
      */
     public function testSetGetClassSignatureGenerator()
     {
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             ClassSignatureGeneratorInterface::class,
             $this->configuration->getClassSignatureGenerator()
         );
@@ -180,6 +180,6 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
         $classSignatureGenerator = $this->getMock(ClassSignatureGeneratorInterface::class);
 
         $this->configuration->setClassSignatureGenerator($classSignatureGenerator);
-        $this->assertSame($classSignatureGenerator, $this->configuration->getClassSignatureGenerator());
+        self::assertSame($classSignatureGenerator, $this->configuration->getClassSignatureGenerator());
     }
 }

--- a/tests/ProxyManagerTest/Exception/DisabledMethodExceptionTest.php
+++ b/tests/ProxyManagerTest/Exception/DisabledMethodExceptionTest.php
@@ -41,6 +41,6 @@ class DisabledMethodExceptionTest extends PHPUnit_Framework_TestCase
     {
         $exception = DisabledMethodException::disabledMethod('foo::bar');
 
-        $this->assertSame('Method "foo::bar" is forcefully disabled', $exception->getMessage());
+        self::assertSame('Method "foo::bar" is forcefully disabled', $exception->getMessage());
     }
 }

--- a/tests/ProxyManagerTest/Exception/FileNotWritableExceptionTest.php
+++ b/tests/ProxyManagerTest/Exception/FileNotWritableExceptionTest.php
@@ -38,8 +38,8 @@ class FileNotWritableExceptionTest extends PHPUnit_Framework_TestCase
     {
         $exception = FileNotWritableException::fromInvalidMoveOperation('/tmp/a', '/tmp/b');
 
-        $this->assertInstanceOf(FileNotWritableException::class, $exception);
-        $this->assertSame(
+        self::assertInstanceOf(FileNotWritableException::class, $exception);
+        self::assertSame(
             'Could not move file "/tmp/a" to location "/tmp/b": either the source file is not readable,'
             . ' or the destination is not writable',
             $exception->getMessage()
@@ -50,8 +50,8 @@ class FileNotWritableExceptionTest extends PHPUnit_Framework_TestCase
     {
         $exception = FileNotWritableException::fromNonWritableLocation(__DIR__);
 
-        $this->assertInstanceOf(FileNotWritableException::class, $exception);
-        $this->assertSame(
+        self::assertInstanceOf(FileNotWritableException::class, $exception);
+        self::assertSame(
             'Could not write to path "' . __DIR__ . '": exists and is not a file',
             $exception->getMessage()
         );
@@ -65,8 +65,8 @@ class FileNotWritableExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = FileNotWritableException::fromNonWritableLocation($path);
 
-        $this->assertInstanceOf(FileNotWritableException::class, $exception);
-        $this->assertSame(
+        self::assertInstanceOf(FileNotWritableException::class, $exception);
+        self::assertSame(
             'Could not write to path "' . $path . '": exists and is not a file, is not writable',
             $exception->getMessage()
         );
@@ -78,8 +78,8 @@ class FileNotWritableExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = FileNotWritableException::fromNonWritableLocation($path . '/foo');
 
-        $this->assertInstanceOf(FileNotWritableException::class, $exception);
-        $this->assertSame(
+        self::assertInstanceOf(FileNotWritableException::class, $exception);
+        self::assertSame(
             'Could not write to path "' . $path . '/foo": path does not exist',
             $exception->getMessage()
         );

--- a/tests/ProxyManagerTest/Exception/InvalidProxiedClassExceptionTest.php
+++ b/tests/ProxyManagerTest/Exception/InvalidProxiedClassExceptionTest.php
@@ -37,7 +37,7 @@ class InvalidProxiedClassExceptionTest extends PHPUnit_Framework_TestCase
 {
     public function testInterfaceNotSupported()
     {
-        $this->assertSame(
+        self::assertSame(
             'Provided interface "ProxyManagerTestAsset\BaseInterface" cannot be proxied',
             InvalidProxiedClassException::interfaceNotSupported(
                 new ReflectionClass('ProxyManagerTestAsset\BaseInterface')
@@ -47,7 +47,7 @@ class InvalidProxiedClassExceptionTest extends PHPUnit_Framework_TestCase
 
     public function testFinalClassNotSupported()
     {
-        $this->assertSame(
+        self::assertSame(
             'Provided class "ProxyManagerTestAsset\FinalClass" is final and cannot be proxied',
             InvalidProxiedClassException::finalClassNotSupported(
                 new ReflectionClass('ProxyManagerTestAsset\FinalClass')
@@ -57,7 +57,7 @@ class InvalidProxiedClassExceptionTest extends PHPUnit_Framework_TestCase
 
     public function testAbstractProtectedMethodsNotSupported()
     {
-        $this->assertSame(
+        self::assertSame(
             'Provided class "ProxyManagerTestAsset\ClassWithAbstractProtectedMethod" has following protected abstract'
             . ' methods, and therefore cannot be proxied:' . "\n"
             . 'ProxyManagerTestAsset\ClassWithAbstractProtectedMethod::protectedAbstractMethod',

--- a/tests/ProxyManagerTest/Exception/InvalidProxyDirectoryExceptionTest.php
+++ b/tests/ProxyManagerTest/Exception/InvalidProxyDirectoryExceptionTest.php
@@ -41,6 +41,6 @@ class InvalidProxyDirectoryExceptionTest extends PHPUnit_Framework_TestCase
     {
         $exception = InvalidProxyDirectoryException::proxyDirectoryNotFound('foo/bar');
 
-        $this->assertSame('Provided directory "foo/bar" does not exist', $exception->getMessage());
+        self::assertSame('Provided directory "foo/bar" does not exist', $exception->getMessage());
     }
 }

--- a/tests/ProxyManagerTest/Exception/UnsupportedProxiedClassExceptionTest.php
+++ b/tests/ProxyManagerTest/Exception/UnsupportedProxiedClassExceptionTest.php
@@ -41,7 +41,7 @@ class UnsupportedProxiedClassExceptionTest extends PHPUnit_Framework_TestCase
      */
     public function testUnsupportedLocalizedReflectionProperty()
     {
-        $this->assertSame(
+        self::assertSame(
             'Provided reflection property "property0" of class "' . ClassWithPrivateProperties::class
             . '" is private and cannot be localized in PHP 5.3',
             UnsupportedProxiedClassException::unsupportedLocalizedReflectionProperty(

--- a/tests/ProxyManagerTest/Factory/AbstractBaseFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AbstractBaseFactoryTest.php
@@ -94,39 +94,39 @@ class AbstractBaseFactoryTest extends PHPUnit_Framework_TestCase
         $this->classSignatureGenerator = $this->getMock(ClassSignatureGeneratorInterface::class);
 
         $configuration
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will($this->returnValue($this->classNameInflector));
+            ->will(self::returnValue($this->classNameInflector));
 
         $configuration
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getGeneratorStrategy')
-            ->will($this->returnValue($this->generatorStrategy));
+            ->will(self::returnValue($this->generatorStrategy));
 
         $configuration
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getProxyAutoloader')
-            ->will($this->returnValue($this->proxyAutoloader));
+            ->will(self::returnValue($this->proxyAutoloader));
 
         $configuration
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will($this->returnValue($this->signatureChecker));
+            ->will(self::returnValue($this->signatureChecker));
 
         $configuration
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will($this->returnValue($this->classSignatureGenerator));
+            ->will(self::returnValue($this->classSignatureGenerator));
 
         $this
             ->classNameInflector
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getUserClassName')
-            ->will($this->returnValue('stdClass'));
+            ->will(self::returnValue('stdClass'));
 
         $this->factory = $this->getMockForAbstractClass(AbstractBaseFactory::class, [$configuration]);
 
-        $this->factory->expects($this->any())->method('getGenerator')->will($this->returnValue($this->generator));
+        $this->factory->expects(self::any())->method('getGenerator')->will(self::returnValue($this->generator));
     }
 
     public function testGeneratesClass()
@@ -138,47 +138,47 @@ class AbstractBaseFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->classNameInflector
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will($this->returnValue($generatedClass));
+            ->will(self::returnValue($generatedClass));
 
         $this
             ->generatorStrategy
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generate')
-            ->with($this->isInstanceOf(ClassGenerator::class));
+            ->with(self::isInstanceOf(ClassGenerator::class));
         $this
             ->proxyAutoloader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($generatedClass)
-            ->will($this->returnCallback(function ($className) : bool {
+            ->will(self::returnCallback(function ($className) : bool {
                 eval('class ' . $className . ' {}');
 
                 return true;
             }));
 
-        $this->signatureChecker->expects($this->atLeastOnce())->method('checkSignature');
-        $this->classSignatureGenerator->expects($this->once())->method('addSignature')->will($this->returnArgument(0));
+        $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
+        $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
         $this
             ->generator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generate')
             ->with(
-                $this->callback(function (\ReflectionClass $reflectionClass) : bool {
+                self::callback(function (\ReflectionClass $reflectionClass) : bool {
                     return $reflectionClass->getName() === 'stdClass';
                 }),
-                $this->isInstanceOf(ClassGenerator::class),
+                self::isInstanceOf(ClassGenerator::class),
                 ['some' => 'proxy', 'options' => 'here']
             );
 
-        $this->assertSame(
+        self::assertSame(
             $generatedClass,
             $generateProxy->invoke($this->factory, stdClass::class, ['some' => 'proxy', 'options' => 'here'])
         );
-        $this->assertTrue(class_exists($generatedClass, false));
-        $this->assertSame(
+        self::assertTrue(class_exists($generatedClass, false));
+        self::assertSame(
             $generatedClass,
             $generateProxy->invoke($this->factory, stdClass::class, ['some' => 'proxy', 'options' => 'here'])
         );

--- a/tests/ProxyManagerTest/Factory/AccessInterceptorScopeLocalizerFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AccessInterceptorScopeLocalizerFactoryTest.php
@@ -76,21 +76,21 @@ class AccessInterceptorScopeLocalizerFactoryTest extends PHPUnit_Framework_TestC
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will($this->returnValue($this->inflector));
+            ->will(self::returnValue($this->inflector));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will($this->returnValue($this->signatureChecker));
+            ->will(self::returnValue($this->signatureChecker));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will($this->returnValue($this->classSignatureGenerator));
+            ->will(self::returnValue($this->classSignatureGenerator));
     }
 
     /**
@@ -101,8 +101,8 @@ class AccessInterceptorScopeLocalizerFactoryTest extends PHPUnit_Framework_TestC
     public function testWithOptionalFactory()
     {
         $factory = new AccessInterceptorValueHolderFactory();
-        $this->assertAttributeNotEmpty('configuration', $factory);
-        $this->assertAttributeInstanceOf(Configuration::class, 'configuration', $factory);
+        self::assertAttributeNotEmpty('configuration', $factory);
+        self::assertAttributeInstanceOf(Configuration::class, 'configuration', $factory);
     }
 
     /**
@@ -118,19 +118,19 @@ class AccessInterceptorScopeLocalizerFactoryTest extends PHPUnit_Framework_TestC
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will($this->returnValue(AccessInterceptorValueHolderMock::class));
+            ->will(self::returnValue(AccessInterceptorValueHolderMock::class));
 
         $factory     = new AccessInterceptorScopeLocalizerFactory($this->config);
         /* @var $proxy AccessInterceptorValueHolderMock */
         $proxy       = $factory->createProxy($instance, ['foo'], ['bar']);
 
-        $this->assertInstanceOf(AccessInterceptorValueHolderMock::class, $proxy);
-        $this->assertSame($instance, $proxy->instance);
-        $this->assertSame(['foo'], $proxy->prefixInterceptors);
-        $this->assertSame(['bar'], $proxy->suffixInterceptors);
+        self::assertInstanceOf(AccessInterceptorValueHolderMock::class, $proxy);
+        self::assertSame($instance, $proxy->instance);
+        self::assertSame(['foo'], $proxy->prefixInterceptors);
+        self::assertSame(['bar'], $proxy->suffixInterceptors);
     }
 
     /**
@@ -149,14 +149,14 @@ class AccessInterceptorScopeLocalizerFactoryTest extends PHPUnit_Framework_TestC
         $generator      = $this->getMock('ProxyManager\GeneratorStrategy\\GeneratorStrategyInterface');
         $autoloader     = $this->getMock(AutoloaderInterface::class);
 
-        $this->config->expects($this->any())->method('getGeneratorStrategy')->will($this->returnValue($generator));
-        $this->config->expects($this->any())->method('getProxyAutoloader')->will($this->returnValue($autoloader));
+        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generate')
             ->with(
-                $this->callback(
+                self::callback(
                     function (ClassGenerator $targetClass) use ($proxyClassName) : bool {
                         return $targetClass->getName() === $proxyClassName;
                     }
@@ -165,7 +165,7 @@ class AccessInterceptorScopeLocalizerFactoryTest extends PHPUnit_Framework_TestC
 
         // simulate autoloading
         $autoloader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxyClassName)
             ->willReturnCallback(function () use ($proxyClassName) : bool {
@@ -179,28 +179,28 @@ class AccessInterceptorScopeLocalizerFactoryTest extends PHPUnit_Framework_TestC
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will($this->returnValue($proxyClassName));
+            ->will(self::returnValue($proxyClassName));
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getUserClassName')
             ->with('stdClass')
-            ->will($this->returnValue(LazyLoadingMock::class));
+            ->will(self::returnValue(LazyLoadingMock::class));
 
-        $this->signatureChecker->expects($this->atLeastOnce())->method('checkSignature');
-        $this->classSignatureGenerator->expects($this->once())->method('addSignature')->will($this->returnArgument(0));
+        $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
+        $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
 
         $factory     = new AccessInterceptorScopeLocalizerFactory($this->config);
         /* @var $proxy AccessInterceptorValueHolderMock */
         $proxy       = $factory->createProxy($instance, ['foo'], ['bar']);
 
-        $this->assertInstanceOf($proxyClassName, $proxy);
-        $this->assertSame($instance, $proxy->instance);
-        $this->assertSame(['foo'], $proxy->prefixInterceptors);
-        $this->assertSame(['bar'], $proxy->suffixInterceptors);
+        self::assertInstanceOf($proxyClassName, $proxy);
+        self::assertSame($instance, $proxy->instance);
+        self::assertSame(['foo'], $proxy->prefixInterceptors);
+        self::assertSame(['bar'], $proxy->suffixInterceptors);
     }
 }

--- a/tests/ProxyManagerTest/Factory/AccessInterceptorValueHolderFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AccessInterceptorValueHolderFactoryTest.php
@@ -75,21 +75,21 @@ class AccessInterceptorValueHolderFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will($this->returnValue($this->inflector));
+            ->will(self::returnValue($this->inflector));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will($this->returnValue($this->signatureChecker));
+            ->will(self::returnValue($this->signatureChecker));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will($this->returnValue($this->classSignatureGenerator));
+            ->will(self::returnValue($this->classSignatureGenerator));
     }
 
     /**
@@ -100,8 +100,8 @@ class AccessInterceptorValueHolderFactoryTest extends PHPUnit_Framework_TestCase
     public function testWithOptionalFactory()
     {
         $factory = new AccessInterceptorValueHolderFactory();
-        $this->assertAttributeNotEmpty('configuration', $factory);
-        $this->assertAttributeInstanceOf(Configuration::class, 'configuration', $factory);
+        self::assertAttributeNotEmpty('configuration', $factory);
+        self::assertAttributeInstanceOf(Configuration::class, 'configuration', $factory);
     }
 
     /**
@@ -117,19 +117,19 @@ class AccessInterceptorValueHolderFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will($this->returnValue(AccessInterceptorValueHolderMock::class));
+            ->will(self::returnValue(AccessInterceptorValueHolderMock::class));
 
         $factory     = new AccessInterceptorValueHolderFactory($this->config);
         /* @var $proxy AccessInterceptorValueHolderMock */
         $proxy       = $factory->createProxy($instance, ['foo'], ['bar']);
 
-        $this->assertInstanceOf(AccessInterceptorValueHolderMock::class, $proxy);
-        $this->assertSame($instance, $proxy->instance);
-        $this->assertSame(['foo'], $proxy->prefixInterceptors);
-        $this->assertSame(['bar'], $proxy->suffixInterceptors);
+        self::assertInstanceOf(AccessInterceptorValueHolderMock::class, $proxy);
+        self::assertSame($instance, $proxy->instance);
+        self::assertSame(['foo'], $proxy->prefixInterceptors);
+        self::assertSame(['bar'], $proxy->suffixInterceptors);
     }
 
     /**
@@ -148,14 +148,14 @@ class AccessInterceptorValueHolderFactoryTest extends PHPUnit_Framework_TestCase
         $generator      = $this->getMock('ProxyManager\GeneratorStrategy\\GeneratorStrategyInterface');
         $autoloader     = $this->getMock(AutoloaderInterface::class);
 
-        $this->config->expects($this->any())->method('getGeneratorStrategy')->will($this->returnValue($generator));
-        $this->config->expects($this->any())->method('getProxyAutoloader')->will($this->returnValue($autoloader));
+        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generate')
             ->with(
-                $this->callback(
+                self::callback(
                     function (ClassGenerator $targetClass) use ($proxyClassName) : bool {
                         return $targetClass->getName() === $proxyClassName;
                     }
@@ -164,7 +164,7 @@ class AccessInterceptorValueHolderFactoryTest extends PHPUnit_Framework_TestCase
 
         // simulate autoloading
         $autoloader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxyClassName)
             ->willReturnCallback(function () use ($proxyClassName) : bool {
@@ -178,28 +178,28 @@ class AccessInterceptorValueHolderFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will($this->returnValue($proxyClassName));
+            ->will(self::returnValue($proxyClassName));
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getUserClassName')
             ->with('stdClass')
-            ->will($this->returnValue(EmptyClass::class));
+            ->will(self::returnValue(EmptyClass::class));
 
-        $this->signatureChecker->expects($this->atLeastOnce())->method('checkSignature');
-        $this->classSignatureGenerator->expects($this->once())->method('addSignature')->will($this->returnArgument(0));
+        $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
+        $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
 
         $factory     = new AccessInterceptorValueHolderFactory($this->config);
         /* @var $proxy AccessInterceptorValueHolderMock */
         $proxy       = $factory->createProxy($instance, ['foo'], ['bar']);
 
-        $this->assertInstanceOf($proxyClassName, $proxy);
-        $this->assertSame($instance, $proxy->instance);
-        $this->assertSame(['foo'], $proxy->prefixInterceptors);
-        $this->assertSame(['bar'], $proxy->suffixInterceptors);
+        self::assertInstanceOf($proxyClassName, $proxy);
+        self::assertSame($instance, $proxy->instance);
+        self::assertSame(['foo'], $proxy->prefixInterceptors);
+        self::assertSame(['bar'], $proxy->suffixInterceptors);
     }
 }

--- a/tests/ProxyManagerTest/Factory/LazyLoadingGhostFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/LazyLoadingGhostFactoryTest.php
@@ -74,21 +74,21 @@ class LazyLoadingGhostFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will($this->returnValue($this->inflector));
+            ->will(self::returnValue($this->inflector));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will($this->returnValue($this->signatureChecker));
+            ->will(self::returnValue($this->signatureChecker));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will($this->returnValue($this->classSignatureGenerator));
+            ->will(self::returnValue($this->classSignatureGenerator));
     }
 
     /**
@@ -99,8 +99,8 @@ class LazyLoadingGhostFactoryTest extends PHPUnit_Framework_TestCase
     public function testWithOptionalFactory()
     {
         $factory = new LazyLoadingGhostFactory();
-        $this->assertAttributeNotEmpty('configuration', $factory);
-        $this->assertAttributeInstanceOf(Configuration::class, 'configuration', $factory);
+        self::assertAttributeNotEmpty('configuration', $factory);
+        self::assertAttributeInstanceOf(Configuration::class, 'configuration', $factory);
     }
 
     /**
@@ -115,10 +115,10 @@ class LazyLoadingGhostFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with($className)
-            ->will($this->returnValue(LazyLoadingMock::class));
+            ->will(self::returnValue(LazyLoadingMock::class));
 
         $factory     = new LazyLoadingGhostFactory($this->config);
         $initializer = function () {
@@ -126,8 +126,8 @@ class LazyLoadingGhostFactoryTest extends PHPUnit_Framework_TestCase
         /* @var $proxy LazyLoadingMock */
         $proxy       = $factory->createProxy($className, $initializer);
 
-        $this->assertInstanceOf(LazyLoadingMock::class, $proxy);
-        $this->assertSame($initializer, $proxy->initializer);
+        self::assertInstanceOf(LazyLoadingMock::class, $proxy);
+        self::assertSame($initializer, $proxy->initializer);
     }
 
     /**
@@ -146,14 +146,14 @@ class LazyLoadingGhostFactoryTest extends PHPUnit_Framework_TestCase
         $generator      = $this->getMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->getMock(AutoloaderInterface::class);
 
-        $this->config->expects($this->any())->method('getGeneratorStrategy')->will($this->returnValue($generator));
-        $this->config->expects($this->any())->method('getProxyAutoloader')->will($this->returnValue($autoloader));
+        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generate')
             ->with(
-                $this->callback(
+                self::callback(
                     function (ClassGenerator $targetClass) use ($proxyClassName) : bool {
                         return $targetClass->getName() === $proxyClassName;
                     }
@@ -162,7 +162,7 @@ class LazyLoadingGhostFactoryTest extends PHPUnit_Framework_TestCase
 
         // simulate autoloading
         $autoloader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxyClassName)
             ->willReturnCallback(function () use ($proxyClassName) : bool {
@@ -173,20 +173,20 @@ class LazyLoadingGhostFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with($className)
-            ->will($this->returnValue($proxyClassName));
+            ->will(self::returnValue($proxyClassName));
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getUserClassName')
             ->with($className)
-            ->will($this->returnValue(LazyLoadingMock::class));
+            ->will(self::returnValue(LazyLoadingMock::class));
 
-        $this->signatureChecker->expects($this->atLeastOnce())->method('checkSignature');
-        $this->classSignatureGenerator->expects($this->once())->method('addSignature')->will($this->returnArgument(0));
+        $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
+        $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
 
         $factory     = new LazyLoadingGhostFactory($this->config);
         $initializer = function () {
@@ -194,7 +194,7 @@ class LazyLoadingGhostFactoryTest extends PHPUnit_Framework_TestCase
         /* @var $proxy LazyLoadingMock */
         $proxy       = $factory->createProxy($className, $initializer);
 
-        $this->assertInstanceOf($proxyClassName, $proxy);
-        $this->assertSame($initializer, $proxy->initializer);
+        self::assertInstanceOf($proxyClassName, $proxy);
+        self::assertSame($initializer, $proxy->initializer);
     }
 }

--- a/tests/ProxyManagerTest/Factory/LazyLoadingValueHolderFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/LazyLoadingValueHolderFactoryTest.php
@@ -75,21 +75,21 @@ class LazyLoadingValueHolderFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will($this->returnValue($this->inflector));
+            ->will(self::returnValue($this->inflector));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will($this->returnValue($this->signatureChecker));
+            ->will(self::returnValue($this->signatureChecker));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will($this->returnValue($this->classSignatureGenerator));
+            ->will(self::returnValue($this->classSignatureGenerator));
     }
 
     /**
@@ -100,8 +100,8 @@ class LazyLoadingValueHolderFactoryTest extends PHPUnit_Framework_TestCase
     public function testWithOptionalFactory()
     {
         $factory = new LazyLoadingValueHolderFactory();
-        $this->assertAttributeNotEmpty('configuration', $factory);
-        $this->assertAttributeInstanceOf(Configuration::class, 'configuration', $factory);
+        self::assertAttributeNotEmpty('configuration', $factory);
+        self::assertAttributeInstanceOf(Configuration::class, 'configuration', $factory);
     }
 
     /**
@@ -116,10 +116,10 @@ class LazyLoadingValueHolderFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with($className)
-            ->will($this->returnValue(LazyLoadingMock::class));
+            ->will(self::returnValue(LazyLoadingMock::class));
 
         $factory     = new LazyLoadingValueHolderFactory($this->config);
         $initializer = function () {
@@ -127,8 +127,8 @@ class LazyLoadingValueHolderFactoryTest extends PHPUnit_Framework_TestCase
         /* @var $proxy LazyLoadingMock */
         $proxy       = $factory->createProxy($className, $initializer);
 
-        $this->assertInstanceOf(LazyLoadingMock::class, $proxy);
-        $this->assertSame($initializer, $proxy->initializer);
+        self::assertInstanceOf(LazyLoadingMock::class, $proxy);
+        self::assertSame($initializer, $proxy->initializer);
     }
 
     /**
@@ -147,14 +147,14 @@ class LazyLoadingValueHolderFactoryTest extends PHPUnit_Framework_TestCase
         $generator      = $this->getMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->getMock(AutoloaderInterface::class);
 
-        $this->config->expects($this->any())->method('getGeneratorStrategy')->will($this->returnValue($generator));
-        $this->config->expects($this->any())->method('getProxyAutoloader')->will($this->returnValue($autoloader));
+        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generate')
             ->with(
-                $this->callback(
+                self::callback(
                     function (ClassGenerator $targetClass) use ($proxyClassName) : bool {
                         return $targetClass->getName() === $proxyClassName;
                     }
@@ -163,7 +163,7 @@ class LazyLoadingValueHolderFactoryTest extends PHPUnit_Framework_TestCase
 
         // simulate autoloading
         $autoloader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxyClassName)
             ->willReturnCallback(function () use ($proxyClassName) : bool {
@@ -174,20 +174,20 @@ class LazyLoadingValueHolderFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with($className)
-            ->will($this->returnValue($proxyClassName));
+            ->will(self::returnValue($proxyClassName));
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getUserClassName')
             ->with($className)
-            ->will($this->returnValue(EmptyClass::class));
+            ->will(self::returnValue(EmptyClass::class));
 
-        $this->signatureChecker->expects($this->atLeastOnce())->method('checkSignature');
-        $this->classSignatureGenerator->expects($this->once())->method('addSignature')->will($this->returnArgument(0));
+        $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
+        $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
 
         $factory     = new LazyLoadingValueHolderFactory($this->config);
         $initializer = function () {
@@ -195,8 +195,8 @@ class LazyLoadingValueHolderFactoryTest extends PHPUnit_Framework_TestCase
         /* @var $proxy LazyLoadingMock */
         $proxy       = $factory->createProxy($className, $initializer);
 
-        $this->assertInstanceOf($proxyClassName, $proxy);
-        $this->assertSame($proxyClassName, get_class($proxy));
-        $this->assertSame($initializer, $proxy->initializer);
+        self::assertInstanceOf($proxyClassName, $proxy);
+        self::assertSame($proxyClassName, get_class($proxy));
+        self::assertSame($initializer, $proxy->initializer);
     }
 }

--- a/tests/ProxyManagerTest/Factory/NullObjectFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/NullObjectFactoryTest.php
@@ -74,21 +74,21 @@ class NullObjectFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will($this->returnValue($this->inflector));
+            ->will(self::returnValue($this->inflector));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will($this->returnValue($this->signatureChecker));
+            ->will(self::returnValue($this->signatureChecker));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will($this->returnValue($this->classSignatureGenerator));
+            ->will(self::returnValue($this->classSignatureGenerator));
     }
 
     /**
@@ -104,16 +104,16 @@ class NullObjectFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will($this->returnValue(NullObjectMock::class));
+            ->will(self::returnValue(NullObjectMock::class));
 
         $factory    = new NullObjectFactory($this->config);
         /* @var $proxy NullObjectMock */
         $proxy      = $factory->createProxy($instance);
 
-        $this->assertInstanceOf(NullObjectMock::class, $proxy);
+        self::assertInstanceOf(NullObjectMock::class, $proxy);
     }
 
     /**
@@ -132,14 +132,14 @@ class NullObjectFactoryTest extends PHPUnit_Framework_TestCase
         $generator      = $this->getMock('ProxyManager\GeneratorStrategy\\GeneratorStrategyInterface');
         $autoloader     = $this->getMock(AutoloaderInterface::class);
 
-        $this->config->expects($this->any())->method('getGeneratorStrategy')->will($this->returnValue($generator));
-        $this->config->expects($this->any())->method('getProxyAutoloader')->will($this->returnValue($autoloader));
+        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generate')
             ->with(
-                $this->callback(
+                self::callback(
                     function (ClassGenerator $targetClass) use ($proxyClassName) : bool {
                         return $targetClass->getName() === $proxyClassName;
                     }
@@ -148,7 +148,7 @@ class NullObjectFactoryTest extends PHPUnit_Framework_TestCase
 
         // simulate autoloading
         $autoloader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxyClassName)
             ->willReturnCallback(function () use ($proxyClassName) : bool {
@@ -159,25 +159,25 @@ class NullObjectFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will($this->returnValue($proxyClassName));
+            ->will(self::returnValue($proxyClassName));
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getUserClassName')
             ->with('stdClass')
-            ->will($this->returnValue(NullObjectMock::class));
+            ->will(self::returnValue(NullObjectMock::class));
 
-        $this->signatureChecker->expects($this->atLeastOnce())->method('checkSignature');
-        $this->classSignatureGenerator->expects($this->once())->method('addSignature')->will($this->returnArgument(0));
+        $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
+        $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
 
         $factory    = new NullObjectFactory($this->config);
         /* @var $proxy NullObjectMock */
         $proxy      = $factory->createProxy($instance);
 
-        $this->assertInstanceOf($proxyClassName, $proxy);
+        self::assertInstanceOf($proxyClassName, $proxy);
     }
 }

--- a/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/BaseAdapterTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/BaseAdapterTest.php
@@ -53,18 +53,18 @@ class BaseAdapterTest extends PHPUnit_Framework_TestCase
         );
 
         $client
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('call')
             ->with('foobarbaz', ['tab' => 'taz'])
-            ->will($this->returnValue('baz'));
+            ->will(self::returnValue('baz'));
 
         $adapter
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getServiceName')
             ->with('foo', 'bar')
-            ->will($this->returnValue('foobarbaz'));
+            ->will(self::returnValue('foobarbaz'));
 
-        $this->assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
+        self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }
 
     /**
@@ -87,17 +87,17 @@ class BaseAdapterTest extends PHPUnit_Framework_TestCase
         );
 
         $client
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('call')
             ->with('mapped', ['tab' => 'taz'])
-            ->will($this->returnValue('baz'));
+            ->will(self::returnValue('baz'));
 
         $adapter
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getServiceName')
             ->with('foo', 'bar')
-            ->will($this->returnValue('foobarbaz'));
+            ->will(self::returnValue('foobarbaz'));
 
-        $this->assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
+        self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }
 }

--- a/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/JsonRpcTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/JsonRpcTest.php
@@ -48,11 +48,11 @@ class JsonRpcTest extends PHPUnit_Framework_TestCase
         $adapter = new JsonRpc($client);
 
         $client
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('call')
             ->with('foo.bar', ['tab' => 'taz'])
-            ->will($this->returnValue('baz'));
+            ->will(self::returnValue('baz'));
 
-        $this->assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
+        self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }
 }

--- a/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/SoapTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/SoapTest.php
@@ -48,11 +48,11 @@ class SoapTest extends PHPUnit_Framework_TestCase
         $adapter = new Soap($client);
 
         $client
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('call')
             ->with('bar', ['tab' => 'taz'])
-            ->will($this->returnValue('baz'));
+            ->will(self::returnValue('baz'));
 
-        $this->assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
+        self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }
 }

--- a/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/XmlRpcTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/XmlRpcTest.php
@@ -48,11 +48,11 @@ class XmlRpcTest extends PHPUnit_Framework_TestCase
         $adapter = new XmlRpc($client);
 
         $client
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('call')
             ->with('foo.bar', ['tab' => 'taz'])
-            ->will($this->returnValue('baz'));
+            ->will(self::returnValue('baz'));
 
-        $this->assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
+        self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }
 }

--- a/tests/ProxyManagerTest/Factory/RemoteObjectFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObjectFactoryTest.php
@@ -76,21 +76,21 @@ class RemoteObjectFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will($this->returnValue($this->inflector));
+            ->will(self::returnValue($this->inflector));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will($this->returnValue($this->signatureChecker));
+            ->will(self::returnValue($this->signatureChecker));
 
         $this
             ->config
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will($this->returnValue($this->classSignatureGenerator));
+            ->will(self::returnValue($this->classSignatureGenerator));
     }
 
     /**
@@ -104,10 +104,10 @@ class RemoteObjectFactoryTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with(BaseInterface::class)
-            ->will($this->returnValue(RemoteObjectMock::class));
+            ->will(self::returnValue(RemoteObjectMock::class));
 
         /* @var $adapter AdapterInterface|\PHPUnit_Framework_MockObject_MockObject */
         $adapter = $this->getMock(AdapterInterface::class);
@@ -115,7 +115,7 @@ class RemoteObjectFactoryTest extends PHPUnit_Framework_TestCase
         /* @var $proxy \stdClass */
         $proxy   = $factory->createProxy(BaseInterface::class, $adapter);
 
-        $this->assertInstanceOf(RemoteObjectMock::class, $proxy);
+        self::assertInstanceOf(RemoteObjectMock::class, $proxy);
     }
 
     /**
@@ -133,14 +133,14 @@ class RemoteObjectFactoryTest extends PHPUnit_Framework_TestCase
         $generator      = $this->getMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->getMock(AutoloaderInterface::class);
 
-        $this->config->expects($this->any())->method('getGeneratorStrategy')->will($this->returnValue($generator));
-        $this->config->expects($this->any())->method('getProxyAutoloader')->will($this->returnValue($autoloader));
+        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('generate')
             ->with(
-                $this->callback(
+                self::callback(
                     function (ClassGenerator $targetClass) use ($proxyClassName) : bool {
                         return $targetClass->getName() === $proxyClassName;
                     }
@@ -149,7 +149,7 @@ class RemoteObjectFactoryTest extends PHPUnit_Framework_TestCase
 
         // simulate autoloading
         $autoloader
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxyClassName)
             ->willReturnCallback(function () use ($proxyClassName) : bool {
@@ -164,26 +164,26 @@ class RemoteObjectFactoryTest extends PHPUnit_Framework_TestCase
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getProxyClassName')
             ->with(BaseInterface::class)
-            ->will($this->returnValue($proxyClassName));
+            ->will(self::returnValue($proxyClassName));
 
         $this
             ->inflector
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getUserClassName')
             ->with(BaseInterface::class)
-            ->will($this->returnValue('stdClass'));
+            ->will(self::returnValue('stdClass'));
 
-        $this->signatureChecker->expects($this->atLeastOnce())->method('checkSignature');
-        $this->classSignatureGenerator->expects($this->once())->method('addSignature')->will($this->returnArgument(0));
+        $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
+        $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
 
         /* @var $adapter AdapterInterface */
         $adapter = $this->getMock(AdapterInterface::class);
         $factory = new RemoteObjectFactory($adapter, $this->config);
         $proxy   = $factory->createProxy(BaseInterface::class, $adapter);
 
-        $this->assertInstanceOf($proxyClassName, $proxy);
+        self::assertInstanceOf($proxyClassName, $proxy);
     }
 }

--- a/tests/ProxyManagerTest/FileLocator/FileLocatorTest.php
+++ b/tests/ProxyManagerTest/FileLocator/FileLocatorTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace ProxyManagerTest\FileLocator;
 
 use PHPUnit_Framework_TestCase;
+use ProxyManager\Exception\InvalidProxyDirectoryException;
 use ProxyManager\FileLocator\FileLocator;
 
 /**
@@ -50,7 +51,7 @@ class FileLocatorTest extends PHPUnit_Framework_TestCase
      */
     public function testRejectsNonExistingDirectory()
     {
-        $this->setExpectedException('ProxyManager\\Exception\\InvalidProxyDirectoryException');
+        $this->expectException(InvalidProxyDirectoryException::class);
         new FileLocator(__DIR__ . '/non-existing');
     }
 }

--- a/tests/ProxyManagerTest/FileLocator/FileLocatorTest.php
+++ b/tests/ProxyManagerTest/FileLocator/FileLocatorTest.php
@@ -41,8 +41,8 @@ class FileLocatorTest extends PHPUnit_Framework_TestCase
     {
         $locator = new FileLocator(__DIR__);
 
-        $this->assertSame(__DIR__ . DIRECTORY_SEPARATOR . 'FooBarBaz.php', $locator->getProxyFileName('Foo\\Bar\\Baz'));
-        $this->assertSame(__DIR__ . DIRECTORY_SEPARATOR . 'Foo_Bar_Baz.php', $locator->getProxyFileName('Foo_Bar_Baz'));
+        self::assertSame(__DIR__ . DIRECTORY_SEPARATOR . 'FooBarBaz.php', $locator->getProxyFileName('Foo\\Bar\\Baz'));
+        self::assertSame(__DIR__ . DIRECTORY_SEPARATOR . 'Foo_Bar_Baz.php', $locator->getProxyFileName('Foo_Bar_Baz'));
     }
 
     /**

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
@@ -534,7 +534,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
 
         self::assertSame(['a', 'b'], (new ClassWithDynamicArgumentsMethod())->dynamicArgumentsMethod('a', 'b'));
 
-        $this->setExpectedException(\PHPUnit_Framework_ExpectationFailedException::class);
+        $this->expectException(\PHPUnit_Framework_ExpectationFailedException::class);
 
         self::assertSame(['a', 'b'], $object->dynamicArgumentsMethod('a', 'b'));
     }

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
@@ -69,12 +69,12 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         $proxy     = $proxyName::staticProxyConstructor($instance);
 
         $this->assertProxySynchronized($instance, $proxy);
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
 
         /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
         $listener = $this->getMock('stdClass', ['__invoke']);
         $listener
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxy, $proxy, $method, $params, false);
 
@@ -85,7 +85,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
             }
         );
 
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
 
         $random = uniqid('', true);
 
@@ -98,7 +98,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
             }
         );
 
-        $this->assertSame($random, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($random, call_user_func_array([$proxy, $method], $params));
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -125,7 +125,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
         $listener  = $this->getMock(stdClass::class, ['__invoke']);
         $listener
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxy, $proxy, $method, $params, $expectedValue, false);
 
@@ -136,7 +136,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
             }
         );
 
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
 
         $random = uniqid('', true);
 
@@ -149,7 +149,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
             }
         );
 
-        $this->assertSame($random, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($random, call_user_func_array([$proxy, $method], $params));
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -173,7 +173,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         /* @var $proxy AccessInterceptorInterface */
         $proxy     = unserialize(serialize($proxyName::staticProxyConstructor($instance)));
 
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -200,7 +200,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         $cloned    = clone $proxy;
 
         $this->assertProxySynchronized($instance, $proxy);
-        $this->assertSame($expectedValue, call_user_func_array([$cloned, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$cloned, $method], $params));
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -218,7 +218,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         string $publicProperty,
         $propertyValue
     ) {
-        $this->assertSame($propertyValue, $proxy->$publicProperty);
+        self::assertSame($propertyValue, $proxy->$publicProperty);
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -234,7 +234,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         $newValue               = uniqid();
         $proxy->$publicProperty = $newValue;
 
-        $this->assertSame($newValue, $proxy->$publicProperty);
+        self::assertSame($newValue, $proxy->$publicProperty);
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -247,11 +247,11 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
      */
     public function testPropertyExistence($instance, AccessInterceptorInterface $proxy, string $publicProperty)
     {
-        $this->assertSame(isset($instance->$publicProperty), isset($proxy->$publicProperty));
+        self::assertSame(isset($instance->$publicProperty), isset($proxy->$publicProperty));
         $this->assertProxySynchronized($instance, $proxy);
 
         $instance->$publicProperty = null;
-        $this->assertFalse(isset($proxy->$publicProperty));
+        self::assertFalse(isset($proxy->$publicProperty));
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -267,8 +267,8 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         $this->markTestSkipped('It is currently not possible to synchronize properties un-setting');
         unset($proxy->$publicProperty);
 
-        $this->assertFalse(isset($instance->$publicProperty));
-        $this->assertFalse(isset($proxy->$publicProperty));
+        self::assertFalse(isset($instance->$publicProperty));
+        self::assertFalse(isset($proxy->$publicProperty));
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -285,11 +285,11 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
 
         $proxy->arrayProperty['foo'] = 'bar';
 
-        $this->assertSame('bar', $proxy->arrayProperty['foo']);
+        self::assertSame('bar', $proxy->arrayProperty['foo']);
 
         $proxy->arrayProperty = ['tab' => 'taz'];
 
-        $this->assertSame(['tab' => 'taz'], $proxy->arrayProperty);
+        self::assertSame(['tab' => 'taz'], $proxy->arrayProperty);
         $this->assertProxySynchronized($instance, $proxy);
     }
 
@@ -305,13 +305,13 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         $proxy       = $proxyName::staticProxyConstructor($instance);
         $variable    = $proxy->property0;
 
-        $this->assertSame('property0', $variable);
+        self::assertSame('property0', $variable);
 
         $variable = 'foo';
 
-        $this->assertSame('property0', $proxy->property0);
+        self::assertSame('property0', $proxy->property0);
         $this->assertProxySynchronized($instance, $proxy);
-        $this->assertSame('foo', $variable);
+        self::assertSame('foo', $variable);
     }
 
     /**
@@ -325,13 +325,13 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         $proxy       = $proxyName::staticProxyConstructor($instance);
         $variable    = & $proxy->property0;
 
-        $this->assertSame('property0', $variable);
+        self::assertSame('property0', $variable);
 
         $variable = 'foo';
 
-        $this->assertSame('foo', $proxy->property0);
+        self::assertSame('foo', $proxy->property0);
         $this->assertProxySynchronized($instance, $proxy);
-        $this->assertSame('foo', $variable);
+        self::assertSame('foo', $variable);
     }
 
     /**
@@ -342,22 +342,22 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
     {
         $instance = new ClassWithCounterConstructor(10);
 
-        $this->assertSame(10, $instance->amount, 'Verifying that test asset works as expected');
-        $this->assertSame(10, $instance->getAmount(), 'Verifying that test asset works as expected');
+        self::assertSame(10, $instance->amount, 'Verifying that test asset works as expected');
+        self::assertSame(10, $instance->getAmount(), 'Verifying that test asset works as expected');
         $instance->__construct(3);
-        $this->assertSame(13, $instance->amount, 'Verifying that test asset works as expected');
-        $this->assertSame(13, $instance->getAmount(), 'Verifying that test asset works as expected');
+        self::assertSame(13, $instance->amount, 'Verifying that test asset works as expected');
+        self::assertSame(13, $instance->getAmount(), 'Verifying that test asset works as expected');
 
         $proxyName = $this->generateProxy(get_class($instance));
 
         /* @var $proxy ClassWithCounterConstructor */
         $proxy = new $proxyName(15);
 
-        $this->assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
-        $this->assertSame(15, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
+        self::assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
+        self::assertSame(15, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
         $proxy->__construct(5);
-        $this->assertSame(20, $proxy->amount, 'Verifying that the proxy constructor works as expected');
-        $this->assertSame(20, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
+        self::assertSame(20, $proxy->amount, 'Verifying that the proxy constructor works as expected');
+        self::assertSame(20, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
     }
 
     /**
@@ -454,7 +454,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
         foreach (Properties::fromReflectionClass($reflectionClass)->getInstanceProperties() as $property) {
             $property->setAccessible(true);
 
-            $this->assertSame(
+            self::assertSame(
                 $property->getValue($instance),
                 $property->getValue($proxy),
                 'Property "' . $property->getName() . '" is synchronized between instance and proxy'
@@ -478,12 +478,12 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends PHPUnit_Framework_Te
             ]
         );
 
-        $this->assertNull($object->bar);
-        $this->assertNull($object->baz);
+        self::assertNull($object->bar);
+        self::assertNull($object->baz);
 
         $object->foo('Ocramius', 'Malukenho', 'Danizord');
-        $this->assertSame('Ocramius', $object->bar);
-        $this->assertSame(['Malukenho', 'Danizord'], $object->baz);
+        self::assertSame('Ocramius', $object->bar);
+        self::assertSame(['Malukenho', 'Danizord'], $object->baz);
     }
 
     /**

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
@@ -424,7 +424,7 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
 
         self::assertSame(['a', 'b'], (new ClassWithDynamicArgumentsMethod())->dynamicArgumentsMethod('a', 'b'));
 
-        $this->setExpectedException(\PHPUnit_Framework_ExpectationFailedException::class);
+        $this->expectException(\PHPUnit_Framework_ExpectationFailedException::class);
 
         self::assertSame(['a', 'b'], $object->dynamicArgumentsMethod('a', 'b'));
     }

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
@@ -67,13 +67,13 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         /* @var $proxy \ProxyManager\Proxy\AccessInterceptorValueHolderInterface */
         $proxy     = $proxyName::staticProxyConstructor($instance);
 
-        $this->assertSame($instance, $proxy->getWrappedValueHolderValue());
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($instance, $proxy->getWrappedValueHolderValue());
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
 
         /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
         $listener = $this->getMock(stdClass::class, ['__invoke']);
         $listener
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxy, $instance, $method, $params, false);
 
@@ -84,7 +84,7 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
             }
         );
 
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
 
         $random = uniqid('', true);
 
@@ -97,7 +97,7 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
             }
         );
 
-        $this->assertSame($random, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($random, call_user_func_array([$proxy, $method], $params));
     }
 
     /**
@@ -123,7 +123,7 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
         $listener = $this->getMock(stdClass::class, ['__invoke']);
         $listener
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('__invoke')
             ->with($proxy, $instance, $method, $params, $expectedValue, false);
 
@@ -134,7 +134,7 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
             }
         );
 
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
 
         $random = uniqid();
 
@@ -147,7 +147,7 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
             }
         );
 
-        $this->assertSame($random, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($random, call_user_func_array([$proxy, $method], $params));
     }
 
     /**
@@ -170,8 +170,8 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         /* @var $proxy \ProxyManager\Proxy\AccessInterceptorValueHolderInterface */
         $proxy     = unserialize(serialize($proxyName::staticProxyConstructor($instance)));
 
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
-        $this->assertEquals($instance, $proxy->getWrappedValueHolderValue());
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertEquals($instance, $proxy->getWrappedValueHolderValue());
     }
 
     /**
@@ -191,9 +191,9 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         $proxy     = $proxyName::staticProxyConstructor($instance);
         $cloned    = clone $proxy;
 
-        $this->assertNotSame($proxy->getWrappedValueHolderValue(), $cloned->getWrappedValueHolderValue());
-        $this->assertSame($expectedValue, call_user_func_array([$cloned, $method], $params));
-        $this->assertEquals($instance, $cloned->getWrappedValueHolderValue());
+        self::assertNotSame($proxy->getWrappedValueHolderValue(), $cloned->getWrappedValueHolderValue());
+        self::assertSame($expectedValue, call_user_func_array([$cloned, $method], $params));
+        self::assertEquals($instance, $cloned->getWrappedValueHolderValue());
     }
 
     /**
@@ -210,8 +210,8 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         string $publicProperty,
         $propertyValue
     ) {
-        $this->assertSame($propertyValue, $proxy->$publicProperty);
-        $this->assertEquals($instance, $proxy->getWrappedValueHolderValue());
+        self::assertSame($propertyValue, $proxy->$publicProperty);
+        self::assertEquals($instance, $proxy->getWrappedValueHolderValue());
     }
 
     /**
@@ -229,8 +229,8 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         $newValue               = uniqid();
         $proxy->$publicProperty = $newValue;
 
-        $this->assertSame($newValue, $proxy->$publicProperty);
-        $this->assertSame($newValue, $proxy->getWrappedValueHolderValue()->$publicProperty);
+        self::assertSame($newValue, $proxy->$publicProperty);
+        self::assertSame($newValue, $proxy->getWrappedValueHolderValue()->$publicProperty);
     }
 
     /**
@@ -245,11 +245,11 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         AccessInterceptorValueHolderInterface $proxy,
         string $publicProperty
     ) {
-        $this->assertSame(isset($instance->$publicProperty), isset($proxy->$publicProperty));
-        $this->assertEquals($instance, $proxy->getWrappedValueHolderValue());
+        self::assertSame(isset($instance->$publicProperty), isset($proxy->$publicProperty));
+        self::assertEquals($instance, $proxy->getWrappedValueHolderValue());
 
         $proxy->getWrappedValueHolderValue()->$publicProperty = null;
-        $this->assertFalse(isset($proxy->$publicProperty));
+        self::assertFalse(isset($proxy->$publicProperty));
     }
 
     /**
@@ -267,8 +267,8 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         $instance = $proxy->getWrappedValueHolderValue() ? $proxy->getWrappedValueHolderValue() : $instance;
         unset($proxy->$publicProperty);
 
-        $this->assertFalse(isset($instance->$publicProperty));
-        $this->assertFalse(isset($proxy->$publicProperty));
+        self::assertFalse(isset($instance->$publicProperty));
+        self::assertFalse(isset($proxy->$publicProperty));
     }
 
     /**
@@ -284,11 +284,11 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
 
         $proxy->arrayProperty['foo'] = 'bar';
 
-        $this->assertSame('bar', $proxy->arrayProperty['foo']);
+        self::assertSame('bar', $proxy->arrayProperty['foo']);
 
         $proxy->arrayProperty = ['tab' => 'taz'];
 
-        $this->assertSame(['tab' => 'taz'], $proxy->arrayProperty);
+        self::assertSame(['tab' => 'taz'], $proxy->arrayProperty);
     }
 
     /**
@@ -303,12 +303,12 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         $proxy       = $proxyName::staticProxyConstructor($instance);
         $variable    = $proxy->property0;
 
-        $this->assertSame('property0', $variable);
+        self::assertSame('property0', $variable);
 
         $variable = 'foo';
 
-        $this->assertSame('property0', $proxy->property0);
-        $this->assertSame('foo', $variable);
+        self::assertSame('property0', $proxy->property0);
+        self::assertSame('foo', $variable);
     }
 
     /**
@@ -323,12 +323,12 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
         $proxy       = $proxyName::staticProxyConstructor($instance);
         $variable    = & $proxy->property0;
 
-        $this->assertSame('property0', $variable);
+        self::assertSame('property0', $variable);
 
         $variable = 'foo';
 
-        $this->assertSame('foo', $proxy->property0);
-        $this->assertSame('foo', $variable);
+        self::assertSame('foo', $proxy->property0);
+        self::assertSame('foo', $variable);
     }
 
     /**
@@ -339,22 +339,22 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
     {
         $instance = new ClassWithCounterConstructor(10);
 
-        $this->assertSame(10, $instance->amount, 'Verifying that test asset works as expected');
-        $this->assertSame(10, $instance->getAmount(), 'Verifying that test asset works as expected');
+        self::assertSame(10, $instance->amount, 'Verifying that test asset works as expected');
+        self::assertSame(10, $instance->getAmount(), 'Verifying that test asset works as expected');
         $instance->__construct(3);
-        $this->assertSame(13, $instance->amount, 'Verifying that test asset works as expected');
-        $this->assertSame(13, $instance->getAmount(), 'Verifying that test asset works as expected');
+        self::assertSame(13, $instance->amount, 'Verifying that test asset works as expected');
+        self::assertSame(13, $instance->getAmount(), 'Verifying that test asset works as expected');
 
         $proxyName = $this->generateProxy(get_class($instance));
 
         /* @var $proxy ClassWithCounterConstructor */
         $proxy = new $proxyName(15);
 
-        $this->assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
-        $this->assertSame(15, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
+        self::assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
+        self::assertSame(15, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
         $proxy->__construct(5);
-        $this->assertSame(20, $proxy->amount, 'Verifying that the proxy constructor works as expected');
-        $this->assertSame(20, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
+        self::assertSame(20, $proxy->amount, 'Verifying that the proxy constructor works as expected');
+        self::assertSame(20, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
     }
 
     public function testWillForwardVariadicArguments()
@@ -372,12 +372,12 @@ class AccessInterceptorValueHolderFunctionalTest extends PHPUnit_Framework_TestC
             ]
         );
 
-        $this->assertNull($object->bar);
-        $this->assertNull($object->baz);
+        self::assertNull($object->bar);
+        self::assertNull($object->baz);
 
         $object->foo('Ocramius', 'Malukenho', 'Danizord');
-        $this->assertSame('Ocramius', $object->bar);
-        $this->assertSame(['Malukenho', 'Danizord'], $object->baz);
+        self::assertSame('Ocramius', $object->bar);
+        self::assertSame(['Malukenho', 'Danizord'], $object->baz);
     }
 
     /**

--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -74,7 +74,7 @@ class FatalPreventionFunctionalTest extends PHPUnit_Framework_TestCase
             // empty catch: this is actually a supported failure
         }
 
-        $this->assertTrue(true, 'Code generation succeeded: proxy is valid or couldn\'t be generated at all');
+        self::assertTrue(true, 'Code generation succeeded: proxy is valid or couldn\'t be generated at all');
     }
 
     /**

--- a/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
@@ -80,15 +80,15 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         /* @var $proxy GhostObjectInterface */
         $proxy = $proxyName::staticProxyConstructor($this->createInitializer($className, $instance));
 
-        $this->assertFalse($proxy->isProxyInitialized());
+        self::assertFalse($proxy->isProxyInitialized());
 
         /* @var $callProxyMethod callable */
         $callProxyMethod = [$proxy, $method];
         $parameterValues = array_values($params);
 
         self::assertInternalType('callable', $callProxyMethod);
-        $this->assertSame($expectedValue, $callProxyMethod(...$parameterValues));
-        $this->assertTrue($proxy->isProxyInitialized());
+        self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
+        self::assertTrue($proxy->isProxyInitialized());
     }
 
     /**
@@ -151,7 +151,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
             $this->createInitializer($className, $instance)
         )));
 
-        $this->assertTrue($proxy->isProxyInitialized());
+        self::assertTrue($proxy->isProxyInitialized());
 
         /* @var $callProxyMethod callable */
         $callProxyMethod = [$proxy, $method];
@@ -183,7 +183,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $proxy  = $proxyName::staticProxyConstructor($this->createInitializer($className, $instance));
         $cloned = clone $proxy;
 
-        $this->assertTrue($cloned->isProxyInitialized());
+        self::assertTrue($cloned->isProxyInitialized());
 
         /* @var $callProxyMethod callable */
         $callProxyMethod = [$proxy, $method];
@@ -207,8 +207,8 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         string $publicProperty,
         $propertyValue
     ) {
-        $this->assertSame($propertyValue, $proxy->$publicProperty);
-        $this->assertTrue($proxy->isProxyInitialized());
+        self::assertSame($propertyValue, $proxy->$publicProperty);
+        self::assertTrue($proxy->isProxyInitialized());
     }
 
     /**
@@ -223,8 +223,8 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $newValue               = uniqid();
         $proxy->$publicProperty = $newValue;
 
-        $this->assertTrue($proxy->isProxyInitialized());
-        $this->assertSame($newValue, $proxy->$publicProperty);
+        self::assertTrue($proxy->isProxyInitialized());
+        self::assertSame($newValue, $proxy->$publicProperty);
     }
 
     /**
@@ -236,8 +236,8 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
      */
     public function testPropertyExistence($instance, GhostObjectInterface $proxy, string $publicProperty)
     {
-        $this->assertSame(isset($instance->$publicProperty), isset($proxy->$publicProperty));
-        $this->assertTrue($proxy->isProxyInitialized());
+        self::assertSame(isset($instance->$publicProperty), isset($proxy->$publicProperty));
+        self::assertTrue($proxy->isProxyInitialized());
     }
 
     /**
@@ -250,8 +250,8 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
     public function testPropertyAbsence($instance, GhostObjectInterface $proxy, string $publicProperty)
     {
         $proxy->$publicProperty = null;
-        $this->assertFalse(isset($proxy->$publicProperty));
-        $this->assertTrue($proxy->isProxyInitialized());
+        self::assertFalse(isset($proxy->$publicProperty));
+        self::assertTrue($proxy->isProxyInitialized());
     }
 
     /**
@@ -265,9 +265,9 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
     {
         unset($proxy->$publicProperty);
 
-        $this->assertTrue($proxy->isProxyInitialized());
-        $this->assertTrue(isset($instance->$publicProperty));
-        $this->assertFalse(isset($proxy->$publicProperty));
+        self::assertTrue($proxy->isProxyInitialized());
+        self::assertTrue(isset($instance->$publicProperty));
+        self::assertFalse(isset($proxy->$publicProperty));
     }
 
     /**
@@ -284,11 +284,11 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
 
         $proxy->arrayProperty['foo'] = 'bar';
 
-        $this->assertSame('bar', $proxy->arrayProperty['foo']);
+        self::assertSame('bar', $proxy->arrayProperty['foo']);
 
         $proxy->arrayProperty = ['tab' => 'taz'];
 
-        $this->assertSame(['tab' => 'taz'], $proxy->arrayProperty);
+        self::assertSame(['tab' => 'taz'], $proxy->arrayProperty);
     }
 
     /**
@@ -304,12 +304,12 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $proxy       = $proxyName::staticProxyConstructor($initializer);
         $variable    = $proxy->property0;
 
-        $this->assertSame('property0', $variable);
+        self::assertSame('property0', $variable);
 
         $variable = 'foo';
 
-        $this->assertSame('property0', $proxy->property0);
-        $this->assertSame('foo', $variable);
+        self::assertSame('property0', $proxy->property0);
+        self::assertSame('foo', $variable);
     }
 
     /**
@@ -325,12 +325,12 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $proxy       = $proxyName::staticProxyConstructor($initializer);
         $variable    = & $proxy->property0;
 
-        $this->assertSame('property0', $variable);
+        self::assertSame('property0', $variable);
 
         $variable = 'foo';
 
-        $this->assertSame('foo', $proxy->property0);
-        $this->assertSame('foo', $variable);
+        self::assertSame('foo', $proxy->property0);
+        self::assertSame('foo', $variable);
     }
 
     public function testKeepsInitializerWhenNotOverwitten()
@@ -344,7 +344,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
 
         $proxy->initializeProxy();
 
-        $this->assertSame($initializer, $proxy->getProxyInitializer());
+        self::assertSame($initializer, $proxy->getProxyInitializer());
     }
 
     /**
@@ -362,13 +362,13 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $proxy       = $proxyName::staticProxyConstructor($initializer);
 
         $proxy->initializeProxy();
-        $this->assertSame('newValue', $proxy->publicProperty);
+        self::assertSame('newValue', $proxy->publicProperty);
 
         $proxy->publicProperty = 'otherValue';
 
         $proxy->initializeProxy();
 
-        $this->assertSame('otherValue', $proxy->publicProperty);
+        self::assertSame('otherValue', $proxy->publicProperty);
     }
 
     /**
@@ -382,7 +382,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $proxy       = $proxyName::staticProxyConstructor(function () {
         });
 
-        $this->assertSame('property0', $proxy->property0);
+        self::assertSame('property0', $proxy->property0);
     }
 
     /**
@@ -400,7 +400,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $reflectionProperty = new ReflectionProperty($instance, 'property0');
         $reflectionProperty->setAccessible(true);
 
-        $this->assertSame('property0', $reflectionProperty->getValue($proxy));
+        self::assertSame('property0', $reflectionProperty->getValue($proxy));
     }
 
     /**
@@ -418,7 +418,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $reflectionProperty = new ReflectionProperty($instance, 'property0');
         $reflectionProperty->setAccessible(true);
 
-        $this->assertSame('property0', $reflectionProperty->getValue($proxy));
+        self::assertSame('property0', $reflectionProperty->getValue($proxy));
     }
 
     /**
@@ -439,8 +439,8 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $childProperty->setAccessible(true);
         $parentProperty->setAccessible(true);
 
-        $this->assertSame('childClassProperty0', $childProperty->getValue($proxy));
-        $this->assertSame('property0', $parentProperty->getValue($proxy));
+        self::assertSame('childClassProperty0', $childProperty->getValue($proxy));
+        self::assertSame('property0', $parentProperty->getValue($proxy));
     }
 
     /**
@@ -466,8 +466,8 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $childProperty->setAccessible(true);
         $parentProperty->setAccessible(true);
 
-        $this->assertSame('foo', $childProperty->getValue($proxy));
-        $this->assertSame('bar', $parentProperty->getValue($proxy));
+        self::assertSame('foo', $childProperty->getValue($proxy));
+        self::assertSame('bar', $parentProperty->getValue($proxy));
     }
 
     /**
@@ -505,11 +505,11 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $childProperty->setAccessible(true);
         $parentProperty->setAccessible(true);
 
-        $this->assertSame('foo', $childProperty->getValue($proxy1));
-        $this->assertSame('bar', $parentProperty->getValue($proxy1));
+        self::assertSame('foo', $childProperty->getValue($proxy1));
+        self::assertSame('bar', $parentProperty->getValue($proxy1));
 
-        $this->assertSame('baz', $childProperty->getValue($proxy2));
-        $this->assertSame('tab', $parentProperty->getValue($proxy2));
+        self::assertSame('baz', $childProperty->getValue($proxy2));
+        self::assertSame('tab', $parentProperty->getValue($proxy2));
     }
 
     /**
@@ -539,8 +539,8 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
 
         $proxy1->set('privateProperty', 'private1');
         $proxy2->set('privateProperty', 'private2');
-        $this->assertSame('private1', $proxy1->get('privateProperty'));
-        $this->assertSame('private2', $proxy2->get('privateProperty'));
+        self::assertSame('private1', $proxy1->get('privateProperty'));
+        self::assertSame('private2', $proxy2->get('privateProperty'));
     }
 
     /**
@@ -569,10 +569,10 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
             }
         );
 
-        $this->assertTrue($proxy1->has('privateProperty'));
-        $this->assertFalse($proxy2->has('privateProperty'));
-        $this->assertTrue($proxy1->has('privateProperty'));
-        $this->assertFalse($proxy2->has('privateProperty'));
+        self::assertTrue($proxy1->has('privateProperty'));
+        self::assertFalse($proxy2->has('privateProperty'));
+        self::assertTrue($proxy1->has('privateProperty'));
+        self::assertFalse($proxy2->has('privateProperty'));
     }
 
     /**
@@ -600,13 +600,13 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
             }
         );
 
-        $this->assertTrue($proxy1->has('privateProperty'));
+        self::assertTrue($proxy1->has('privateProperty'));
         $proxy2->remove('privateProperty');
-        $this->assertFalse($proxy2->has('privateProperty'));
-        $this->assertTrue($proxy1->has('privateProperty'));
+        self::assertFalse($proxy2->has('privateProperty'));
+        self::assertTrue($proxy1->has('privateProperty'));
         $proxy1->remove('privateProperty');
-        $this->assertFalse($proxy1->has('privateProperty'));
-        $this->assertFalse($proxy2->has('privateProperty'));
+        self::assertFalse($proxy1->has('privateProperty'));
+        self::assertFalse($proxy2->has('privateProperty'));
     }
 
     /**
@@ -640,13 +640,13 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
             }
         );
 
-        $this->assertTrue($proxy1->has('protectedProperty'));
-        $this->assertTrue($proxy1->has('publicProperty'));
-        $this->assertTrue($proxy1->has('privateProperty'));
+        self::assertTrue($proxy1->has('protectedProperty'));
+        self::assertTrue($proxy1->has('publicProperty'));
+        self::assertTrue($proxy1->has('privateProperty'));
 
-        $this->assertFalse($proxy2->has('protectedProperty'));
-        $this->assertFalse($proxy2->has('publicProperty'));
-        $this->assertFalse($proxy2->has('privateProperty'));
+        self::assertFalse($proxy2->has('protectedProperty'));
+        self::assertFalse($proxy2->has('publicProperty'));
+        self::assertFalse($proxy2->has('privateProperty'));
     }
 
     public function testByRefInitialization()
@@ -673,7 +673,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         foreach (Properties::fromReflectionClass($reflectionClass)->getInstanceProperties() as $property) {
             $property->setAccessible(true);
 
-            $this->assertSame(str_replace('Property', '', $property->getName()), $property->getValue($proxy));
+            self::assertSame(str_replace('Property', '', $property->getName()), $property->getValue($proxy));
         }
     }
 
@@ -685,22 +685,22 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
     {
         $instance = new ClassWithCounterConstructor(10);
 
-        $this->assertSame(10, $instance->amount, 'Verifying that test asset works as expected');
-        $this->assertSame(10, $instance->getAmount(), 'Verifying that test asset works as expected');
+        self::assertSame(10, $instance->amount, 'Verifying that test asset works as expected');
+        self::assertSame(10, $instance->getAmount(), 'Verifying that test asset works as expected');
         $instance->__construct(3);
-        $this->assertSame(13, $instance->amount, 'Verifying that test asset works as expected');
-        $this->assertSame(13, $instance->getAmount(), 'Verifying that test asset works as expected');
+        self::assertSame(13, $instance->amount, 'Verifying that test asset works as expected');
+        self::assertSame(13, $instance->getAmount(), 'Verifying that test asset works as expected');
 
         $proxyName = $this->generateProxy(get_class($instance));
 
         /* @var $proxy ClassWithCounterConstructor */
         $proxy = new $proxyName(15);
 
-        $this->assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
-        $this->assertSame(15, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
+        self::assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
+        self::assertSame(15, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
         $proxy->__construct(5);
-        $this->assertSame(20, $proxy->amount, 'Verifying that the proxy constructor works as expected');
-        $this->assertSame(20, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
+        self::assertSame(20, $proxy->amount, 'Verifying that the proxy constructor works as expected');
+        self::assertSame(20, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
     }
 
     public function testInitializeProxyWillReturnTrueOnSuccessfulInitialization()
@@ -713,9 +713,9 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
             new ClassWithMixedProperties()
         ));
 
-        $this->assertTrue($proxy->initializeProxy());
-        $this->assertTrue($proxy->isProxyInitialized());
-        $this->assertFalse($proxy->initializeProxy());
+        self::assertTrue($proxy->initializeProxy());
+        self::assertTrue($proxy->isProxyInitialized());
+        self::assertFalse($proxy->initializeProxy());
     }
 
     /**
@@ -754,12 +754,12 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
             $initializerMatcher = $this->getMock('stdClass', ['__invoke']);
 
             $initializerMatcher
-                ->expects($this->once())
+                ->expects(self::once())
                 ->method('__invoke')
                 ->with(
                     $this->logicalAnd(
-                        $this->isInstanceOf(GhostObjectInterface::class),
-                        $this->isInstanceOf($className)
+                        self::isInstanceOf(GhostObjectInterface::class),
+                        self::isInstanceOf($className)
                     )
                 );
         }
@@ -949,7 +949,7 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
         $property = new ReflectionProperty($propertyClass, $propertyName);
         $property->setAccessible(true);
 
-        $this->assertSame($expected, $property->getValue($ghostObject));
+        self::assertSame($expected, $property->getValue($ghostObject));
     }
 
     /**
@@ -984,9 +984,9 @@ class LazyLoadingGhostFunctionalTest extends PHPUnit_Framework_TestCase
 
         $property->setValue($ghostObject, $value);
 
-        $this->assertTrue($ghostObject->initializeProxy());
+        self::assertTrue($ghostObject->initializeProxy());
 
-        $this->assertSame(
+        self::assertSame(
             $value,
             $property->getValue($ghostObject),
             'Property should not be changed by proxy initialization'

--- a/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
@@ -68,15 +68,15 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
         /* @var $proxy VirtualProxyInterface */
         $proxy = $proxyName::staticProxyConstructor($this->createInitializer($className, $instance));
 
-        $this->assertFalse($proxy->isProxyInitialized());
+        self::assertFalse($proxy->isProxyInitialized());
 
         /* @var $callProxyMethod callable */
         $callProxyMethod = [$proxy, $method];
         $parameterValues = array_values($params);
 
-        $this->assertSame($expectedValue, $callProxyMethod(...$parameterValues));
-        $this->assertTrue($proxy->isProxyInitialized());
-        $this->assertSame($instance, $proxy->getWrappedValueHolderValue());
+        self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
+        self::assertTrue($proxy->isProxyInitialized());
+        self::assertSame($instance, $proxy->getWrappedValueHolderValue());
     }
 
     /**
@@ -102,7 +102,7 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
             $this->createInitializer($className, $instance)
         )));
 
-        $this->assertTrue($proxy->isProxyInitialized());
+        self::assertTrue($proxy->isProxyInitialized());
 
         /* @var $callProxyMethod callable */
         $callProxyMethod = [$proxy, $method];
@@ -110,8 +110,8 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
 
         self::assertInternalType('callable', $callProxyMethod);
 
-        $this->assertSame($expectedValue, $callProxyMethod(...$parameterValues));
-        $this->assertEquals($instance, $proxy->getWrappedValueHolderValue());
+        self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
+        self::assertEquals($instance, $proxy->getWrappedValueHolderValue());
     }
 
     /**
@@ -136,8 +136,8 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
         $proxy  = $proxyName::staticProxyConstructor($this->createInitializer($className, $instance));
         $cloned = clone $proxy;
 
-        $this->assertTrue($cloned->isProxyInitialized());
-        $this->assertNotSame($proxy->getWrappedValueHolderValue(), $cloned->getWrappedValueHolderValue());
+        self::assertTrue($cloned->isProxyInitialized());
+        self::assertNotSame($proxy->getWrappedValueHolderValue(), $cloned->getWrappedValueHolderValue());
 
         /* @var $callProxyMethod callable */
         $callProxyMethod = [$cloned, $method];
@@ -145,8 +145,8 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
 
         self::assertInternalType('callable', $callProxyMethod);
 
-        $this->assertSame($expectedValue, $callProxyMethod(...$parameterValues));
-        $this->assertEquals($instance, $cloned->getWrappedValueHolderValue());
+        self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
+        self::assertEquals($instance, $cloned->getWrappedValueHolderValue());
     }
 
     /**
@@ -163,9 +163,9 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
         string $publicProperty,
         $propertyValue
     ) {
-        $this->assertSame($propertyValue, $proxy->$publicProperty);
-        $this->assertTrue($proxy->isProxyInitialized());
-        $this->assertEquals($instance, $proxy->getWrappedValueHolderValue());
+        self::assertSame($propertyValue, $proxy->$publicProperty);
+        self::assertTrue($proxy->isProxyInitialized());
+        self::assertEquals($instance, $proxy->getWrappedValueHolderValue());
     }
 
     /**
@@ -180,9 +180,9 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
         $newValue               = uniqid();
         $proxy->$publicProperty = $newValue;
 
-        $this->assertTrue($proxy->isProxyInitialized());
-        $this->assertSame($newValue, $proxy->$publicProperty);
-        $this->assertSame($newValue, $proxy->getWrappedValueHolderValue()->$publicProperty);
+        self::assertTrue($proxy->isProxyInitialized());
+        self::assertSame($newValue, $proxy->$publicProperty);
+        self::assertSame($newValue, $proxy->getWrappedValueHolderValue()->$publicProperty);
     }
 
     /**
@@ -194,9 +194,9 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
      */
     public function testPropertyExistence($instance, VirtualProxyInterface $proxy, string $publicProperty)
     {
-        $this->assertSame(isset($instance->$publicProperty), isset($proxy->$publicProperty));
-        $this->assertTrue($proxy->isProxyInitialized());
-        $this->assertEquals($instance, $proxy->getWrappedValueHolderValue());
+        self::assertSame(isset($instance->$publicProperty), isset($proxy->$publicProperty));
+        self::assertTrue($proxy->isProxyInitialized());
+        self::assertEquals($instance, $proxy->getWrappedValueHolderValue());
     }
 
     /**
@@ -210,8 +210,8 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
     {
         $instance = $proxy->getWrappedValueHolderValue() ? $proxy->getWrappedValueHolderValue() : $instance;
         $instance->$publicProperty = null;
-        $this->assertFalse(isset($proxy->$publicProperty));
-        $this->assertTrue($proxy->isProxyInitialized());
+        self::assertFalse(isset($proxy->$publicProperty));
+        self::assertTrue($proxy->isProxyInitialized());
     }
 
     /**
@@ -226,10 +226,10 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
         $instance = $proxy->getWrappedValueHolderValue() ? $proxy->getWrappedValueHolderValue() : $instance;
         unset($proxy->$publicProperty);
 
-        $this->assertTrue($proxy->isProxyInitialized());
+        self::assertTrue($proxy->isProxyInitialized());
 
-        $this->assertFalse(isset($instance->$publicProperty));
-        $this->assertFalse(isset($proxy->$publicProperty));
+        self::assertFalse(isset($instance->$publicProperty));
+        self::assertFalse(isset($proxy->$publicProperty));
     }
 
     /**
@@ -246,11 +246,11 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
 
         $proxy->arrayProperty['foo'] = 'bar';
 
-        $this->assertSame('bar', $proxy->arrayProperty['foo']);
+        self::assertSame('bar', $proxy->arrayProperty['foo']);
 
         $proxy->arrayProperty = ['tab' => 'taz'];
 
-        $this->assertSame(['tab' => 'taz'], $proxy->arrayProperty);
+        self::assertSame(['tab' => 'taz'], $proxy->arrayProperty);
     }
 
     /**
@@ -266,12 +266,12 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
         $proxy       = $proxyName::staticProxyConstructor($initializer);
         $variable    = $proxy->property0;
 
-        $this->assertSame('property0', $variable);
+        self::assertSame('property0', $variable);
 
         $variable = 'foo';
 
-        $this->assertSame('property0', $proxy->property0);
-        $this->assertSame('foo', $variable);
+        self::assertSame('property0', $proxy->property0);
+        self::assertSame('foo', $variable);
     }
 
     /**
@@ -287,12 +287,12 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
         $proxy       = $proxyName::staticProxyConstructor($initializer);
         $variable    = & $proxy->property0;
 
-        $this->assertSame('property0', $variable);
+        self::assertSame('property0', $variable);
 
         $variable = 'foo';
 
-        $this->assertSame('foo', $proxy->property0);
-        $this->assertSame('foo', $variable);
+        self::assertSame('foo', $proxy->property0);
+        self::assertSame('foo', $variable);
     }
 
     /**
@@ -312,9 +312,9 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
             $wrappedInstance->publicProperty = (string) ($counter += 1);
         });
 
-        $this->assertSame('1', $proxy->publicProperty);
-        $this->assertSame('2', $proxy->publicProperty);
-        $this->assertSame('3', $proxy->publicProperty);
+        self::assertSame('1', $proxy->publicProperty);
+        self::assertSame('2', $proxy->publicProperty);
+        self::assertSame('3', $proxy->publicProperty);
     }
 
     /**
@@ -325,22 +325,22 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
     {
         $instance = new ClassWithCounterConstructor(10);
 
-        $this->assertSame(10, $instance->amount, 'Verifying that test asset works as expected');
-        $this->assertSame(10, $instance->getAmount(), 'Verifying that test asset works as expected');
+        self::assertSame(10, $instance->amount, 'Verifying that test asset works as expected');
+        self::assertSame(10, $instance->getAmount(), 'Verifying that test asset works as expected');
         $instance->__construct(3);
-        $this->assertSame(13, $instance->amount, 'Verifying that test asset works as expected');
-        $this->assertSame(13, $instance->getAmount(), 'Verifying that test asset works as expected');
+        self::assertSame(13, $instance->amount, 'Verifying that test asset works as expected');
+        self::assertSame(13, $instance->getAmount(), 'Verifying that test asset works as expected');
 
         $proxyName = $this->generateProxy(get_class($instance));
 
         /* @var $proxy ClassWithCounterConstructor */
         $proxy = new $proxyName(15);
 
-        $this->assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
-        $this->assertSame(15, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
+        self::assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
+        self::assertSame(15, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
         $proxy->__construct(5);
-        $this->assertSame(20, $proxy->amount, 'Verifying that the proxy constructor works as expected');
-        $this->assertSame(20, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
+        self::assertSame(20, $proxy->amount, 'Verifying that the proxy constructor works as expected');
+        self::assertSame(20, $proxy->getAmount(), 'Verifying that the proxy constructor works as expected');
     }
 
     /**
@@ -417,12 +417,12 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
             $initializerMatcher = $this->getMock(stdClass::class, ['__invoke']);
 
             $initializerMatcher
-                ->expects($this->once())
+                ->expects(self::once())
                 ->method('__invoke')
                 ->with(
                     $this->logicalAnd(
-                        $this->isInstanceOf(VirtualProxyInterface::class),
-                        $this->isInstanceOf($className)
+                        self::isInstanceOf(VirtualProxyInterface::class),
+                        self::isInstanceOf($className)
                     ),
                     $realInstance
                 );

--- a/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
@@ -379,7 +379,7 @@ class LazyLoadingValueHolderFunctionalTest extends PHPUnit_Framework_TestCase
 
         self::assertSame(['a', 'b'], (new ClassWithDynamicArgumentsMethod())->dynamicArgumentsMethod('a', 'b'));
 
-        $this->setExpectedException(\PHPUnit_Framework_ExpectationFailedException::class);
+        $this->expectException(\PHPUnit_Framework_ExpectationFailedException::class);
 
         self::assertSame(['a', 'b'], $object->dynamicArgumentsMethod('a', 'b'));
     }

--- a/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
+++ b/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
@@ -86,14 +86,14 @@ class MultipleProxyGenerationTest extends PHPUnit_Framework_TestCase
         ];
 
         foreach ($generated as $key => $proxy) {
-            $this->assertInstanceOf($className, $proxy);
+            self::assertInstanceOf($className, $proxy);
 
             foreach ($generated as $comparedKey => $comparedProxy) {
                 if ($comparedKey === $key) {
                     continue;
                 }
 
-                $this->assertNotSame(get_class($comparedProxy), get_class($proxy));
+                self::assertNotSame(get_class($comparedProxy), get_class($proxy));
             }
 
             $proxyClass = get_class($proxy);
@@ -101,11 +101,11 @@ class MultipleProxyGenerationTest extends PHPUnit_Framework_TestCase
             self::assertInstanceOf($proxyClass, new $proxyClass, 'Proxy can be instantiated via normal constructor');
         }
 
-        $this->assertInstanceOf(GhostObjectInterface::class, $generated[0]);
-        $this->assertInstanceOf(VirtualProxyInterface::class, $generated[1]);
-        $this->assertInstanceOf(AccessInterceptorInterface::class, $generated[2]);
-        $this->assertInstanceOf(ValueHolderInterface::class, $generated[2]);
-        $this->assertInstanceOf(AccessInterceptorInterface::class, $generated[3]);
+        self::assertInstanceOf(GhostObjectInterface::class, $generated[0]);
+        self::assertInstanceOf(VirtualProxyInterface::class, $generated[1]);
+        self::assertInstanceOf(AccessInterceptorInterface::class, $generated[2]);
+        self::assertInstanceOf(ValueHolderInterface::class, $generated[2]);
+        self::assertInstanceOf(AccessInterceptorInterface::class, $generated[3]);
     }
 
     /**

--- a/tests/ProxyManagerTest/Functional/NullObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/NullObjectFunctionalTest.php
@@ -102,7 +102,7 @@ class NullObjectFunctionalTest extends PHPUnit_Framework_TestCase
      */
     public function testPropertyReadAccess(NullObjectInterface $proxy, string $publicProperty)
     {
-        $this->assertSame(null, $proxy->$publicProperty);
+        self::assertSame(null, $proxy->$publicProperty);
     }
 
     /**
@@ -116,7 +116,7 @@ class NullObjectFunctionalTest extends PHPUnit_Framework_TestCase
         $newValue               = uniqid();
         $proxy->$publicProperty = $newValue;
 
-        $this->assertSame($newValue, $proxy->$publicProperty);
+        self::assertSame($newValue, $proxy->$publicProperty);
     }
 
     /**
@@ -127,7 +127,7 @@ class NullObjectFunctionalTest extends PHPUnit_Framework_TestCase
      */
     public function testPropertyExistence(NullObjectInterface $proxy, string $publicProperty)
     {
-        $this->assertSame(null, $proxy->$publicProperty);
+        self::assertSame(null, $proxy->$publicProperty);
     }
 
     /**
@@ -140,7 +140,7 @@ class NullObjectFunctionalTest extends PHPUnit_Framework_TestCase
     {
         unset($proxy->$publicProperty);
 
-        $this->assertFalse(isset($proxy->$publicProperty));
+        self::assertFalse(isset($proxy->$publicProperty));
     }
 
     /**

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -60,10 +60,10 @@ class RemoteObjectFunctionalTest extends PHPUnit_Framework_TestCase
         $client = $this->getMock(Client::class, ['call']);
 
         $client
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('call')
             ->with($this->stringEndsWith($method), $params)
-            ->will($this->returnValue($expectedValue));
+            ->will(self::returnValue($expectedValue));
 
         $adapter = new XmlRpcAdapter(
             $client,
@@ -89,10 +89,10 @@ class RemoteObjectFunctionalTest extends PHPUnit_Framework_TestCase
         $client = $this->getMock(Client::class, ['call']);
 
         $client
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('call')
             ->with($this->stringEndsWith($method), $params)
-            ->will($this->returnValue($expectedValue));
+            ->will(self::returnValue($expectedValue));
 
         $adapter = new JsonRpcAdapter(
             $client,
@@ -120,7 +120,7 @@ class RemoteObjectFunctionalTest extends PHPUnit_Framework_TestCase
         /* @var $proxy \ProxyManager\Proxy\RemoteObjectInterface */
         $proxy     = $proxyName::staticProxyConstructor($this->getXmlRpcAdapter($expectedValue, $method, $params));
 
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
     }
 
     /**
@@ -138,7 +138,7 @@ class RemoteObjectFunctionalTest extends PHPUnit_Framework_TestCase
         /* @var $proxy \ProxyManager\Proxy\RemoteObjectInterface */
         $proxy     = $proxyName::staticProxyConstructor($this->getJsonRpcAdapter($expectedValue, $method, $params));
 
-        $this->assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
+        self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
     }
 
     /**
@@ -158,7 +158,7 @@ class RemoteObjectFunctionalTest extends PHPUnit_Framework_TestCase
         );
 
         /* @var $proxy \ProxyManager\Proxy\NullObjectInterface */
-        $this->assertSame($propertyValue, $proxy->$publicProperty);
+        self::assertSame($propertyValue, $proxy->$publicProperty);
     }
 
     /**

--- a/tests/ProxyManagerTest/Generator/ClassGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/ClassGeneratorTest.php
@@ -47,7 +47,7 @@ class ClassGeneratorTest extends PHPUnit_Framework_TestCase
             $classGenerator = new ClassGenerator();
             $classGenerator->setExtendedClass($className);
 
-            $this->assertEquals($desiredFqcn, $classGenerator->getExtendedClass());
+            self::assertEquals($desiredFqcn, $classGenerator->getExtendedClass());
         }
     }
 
@@ -63,7 +63,7 @@ class ClassGeneratorTest extends PHPUnit_Framework_TestCase
             $classGenerator = new ClassGenerator();
             $classGenerator->setImplementedInterfaces($interfaceNames);
 
-            $this->assertEquals($desiredFqcns, $classGenerator->getImplementedInterfaces());
+            self::assertEquals($desiredFqcns, $classGenerator->getImplementedInterfaces());
         }
     }
 }

--- a/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
@@ -50,7 +50,7 @@ class MethodGeneratorTest extends PHPUnit_Framework_TestCase
         $methodGenerator->setDocBlock('docBlock');
         $methodGenerator->setParameter(new ParameterGenerator('foo'));
 
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             '%a/**%adocBlock%a*/%aprotected function & methodName($foo)%a{%a/* body */%a}',
             $methodGenerator->generate()
         );
@@ -63,18 +63,18 @@ class MethodGeneratorTest extends PHPUnit_Framework_TestCase
     {
         $method = MethodGenerator::fromReflection(new MethodReflection(__CLASS__, __FUNCTION__));
 
-        $this->assertSame(__FUNCTION__, $method->getName());
-        $this->assertSame(MethodGenerator::VISIBILITY_PUBLIC, $method->getVisibility());
-        $this->assertFalse($method->isStatic());
-        $this->assertSame('Verify that building from reflection works', $method->getDocBlock()->getShortDescription());
+        self::assertSame(__FUNCTION__, $method->getName());
+        self::assertSame(MethodGenerator::VISIBILITY_PUBLIC, $method->getVisibility());
+        self::assertFalse($method->isStatic());
+        self::assertSame('Verify that building from reflection works', $method->getDocBlock()->getShortDescription());
 
         $method = MethodGenerator::fromReflection(new MethodReflection(BaseClass::class, 'protectedMethod'));
 
-        $this->assertSame(MethodGenerator::VISIBILITY_PROTECTED, $method->getVisibility());
+        self::assertSame(MethodGenerator::VISIBILITY_PROTECTED, $method->getVisibility());
 
         $method = MethodGenerator::fromReflection(new MethodReflection(BaseClass::class, 'privateMethod'));
 
-        $this->assertSame(MethodGenerator::VISIBILITY_PRIVATE, $method->getVisibility());
+        self::assertSame(MethodGenerator::VISIBILITY_PRIVATE, $method->getVisibility());
     }
 
     public function testGeneratedParametersFromReflection()
@@ -84,15 +84,15 @@ class MethodGeneratorTest extends PHPUnit_Framework_TestCase
             'publicTypeHintedMethod'
         ));
 
-        $this->assertSame('publicTypeHintedMethod', $method->getName());
+        self::assertSame('publicTypeHintedMethod', $method->getName());
 
         $parameters = $method->getParameters();
 
-        $this->assertCount(1, $parameters);
+        self::assertCount(1, $parameters);
 
         $param = $parameters['param'];
 
-        $this->assertSame(stdClass::class, $param->getType());
+        self::assertSame(stdClass::class, $param->getType());
     }
 
     /**
@@ -108,15 +108,15 @@ class MethodGeneratorTest extends PHPUnit_Framework_TestCase
             $methodName
         ));
 
-        $this->assertSame($methodName, $method->getName());
+        self::assertSame($methodName, $method->getName());
 
         $parameters = $method->getParameters();
 
-        $this->assertCount(1, $parameters);
+        self::assertCount(1, $parameters);
 
         $param = $parameters['param'];
 
-        $this->assertSame($type, $param->getType());
+        self::assertSame($type, $param->getType());
     }
 
     public function scalarTypeHintedMethods()

--- a/tests/ProxyManagerTest/Generator/Util/ClassGeneratorUtilsTest.php
+++ b/tests/ProxyManagerTest/Generator/Util/ClassGeneratorUtilsTest.php
@@ -48,7 +48,7 @@ class ClassGeneratorUtilsTest extends PHPUnit_Framework_TestCase
         $methodGenerator = $this->getMock(MethodGenerator::class);
 
         $methodGenerator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getName')
             ->willReturn('foo');
 
@@ -58,7 +58,7 @@ class ClassGeneratorUtilsTest extends PHPUnit_Framework_TestCase
 
         $reflection = new ReflectionClass(ClassWithFinalMethods::class);
 
-        $this->assertFalse(ClassGeneratorUtils::addMethodIfNotFinal($reflection, $classGenerator, $methodGenerator));
+        self::assertFalse(ClassGeneratorUtils::addMethodIfNotFinal($reflection, $classGenerator, $methodGenerator));
     }
 
     public function testCanAddANotFinalMethod()
@@ -69,16 +69,16 @@ class ClassGeneratorUtilsTest extends PHPUnit_Framework_TestCase
         $methodGenerator = $this->getMock(MethodGenerator::class);
 
         $methodGenerator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getName')
             ->willReturn('publicMethod');
 
         $classGenerator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('addMethodFromGenerator');
 
         $reflection = new ReflectionClass(BaseClass::class);
 
-        $this->assertTrue(ClassGeneratorUtils::addMethodIfNotFinal($reflection, $classGenerator, $methodGenerator));
+        self::assertTrue(ClassGeneratorUtils::addMethodIfNotFinal($reflection, $classGenerator, $methodGenerator));
     }
 }

--- a/tests/ProxyManagerTest/Generator/Util/UniqueIdentifierGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/Util/UniqueIdentifierGeneratorTest.php
@@ -42,7 +42,7 @@ class UniqueIdentifierGeneratorTest extends PHPUnit_Framework_TestCase
      */
     public function testGeneratesUniqueIdentifiers(string $name)
     {
-        $this->assertNotSame(
+        self::assertNotSame(
             UniqueIdentifierGenerator::getIdentifier($name),
             UniqueIdentifierGenerator::getIdentifier($name)
         );
@@ -57,7 +57,7 @@ class UniqueIdentifierGeneratorTest extends PHPUnit_Framework_TestCase
      */
     public function testGeneratesValidIdentifiers(string $name)
     {
-        $this->assertRegExp(
+        self::assertRegExp(
             '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+$/',
             UniqueIdentifierGenerator::getIdentifier($name)
         );

--- a/tests/ProxyManagerTest/GeneratorStrategy/BaseGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/BaseGeneratorStrategyTest.php
@@ -45,6 +45,6 @@ class BaseGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         $classGenerator = new ClassGenerator($className);
         $generated      = $strategy->generate($classGenerator);
 
-        $this->assertGreaterThan(0, strpos($generated, $className));
+        self::assertGreaterThan(0, strpos($generated, $className));
     }
 }

--- a/tests/ProxyManagerTest/GeneratorStrategy/EvaluatingGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/EvaluatingGeneratorStrategyTest.php
@@ -46,8 +46,8 @@ class EvaluatingGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         $classGenerator = new ClassGenerator($className);
         $generated      = $strategy->generate($classGenerator);
 
-        $this->assertGreaterThan(0, strpos($generated, $className));
-        $this->assertTrue(class_exists($className, false));
+        self::assertGreaterThan(0, strpos($generated, $className));
+        self::assertTrue(class_exists($className, false));
     }
 
     /**
@@ -65,7 +65,7 @@ class EvaluatingGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         $classGenerator = new ClassGenerator($className);
         $generated      = $strategy->generate($classGenerator);
 
-        $this->assertGreaterThan(0, strpos($generated, $className));
-        $this->assertTrue(class_exists($className, false));
+        self::assertGreaterThan(0, strpos($generated, $className));
+        self::assertTrue(class_exists($className, false));
     }
 }

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -51,21 +51,21 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         $fqcn      = $namespace . '\\' . $className;
 
         $locator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getProxyFileName')
             ->with($fqcn)
-            ->will($this->returnValue($tmpFile));
+            ->will(self::returnValue($tmpFile));
 
         $body = $generator->generate(new ClassGenerator($fqcn));
 
-        $this->assertGreaterThan(0, strpos($body, $className));
-        $this->assertFalse(class_exists($fqcn, false));
-        $this->assertTrue(file_exists($tmpFile));
+        self::assertGreaterThan(0, strpos($body, $className));
+        self::assertFalse(class_exists($fqcn, false));
+        self::assertTrue(file_exists($tmpFile));
 
         /* @noinspection PhpIncludeInspection */
         require $tmpFile;
 
-        $this->assertTrue(class_exists($fqcn, false));
+        self::assertTrue(class_exists($fqcn, false));
     }
 
     public function testGenerateWillFailIfTmpFileCannotBeWrittenToDisk()
@@ -83,10 +83,10 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         $fqcn      = $namespace . '\\' . $className;
 
         $locator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getProxyFileName')
             ->with($fqcn)
-            ->will($this->returnValue($tmpFile));
+            ->will(self::returnValue($tmpFile));
 
         $this->setExpectedException(FileNotWritableException::class);
         $generator->generate(new ClassGenerator($fqcn));
@@ -103,10 +103,10 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         $fqcn      = $namespace . '\\' . $className;
 
         $locator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getProxyFileName')
             ->with($fqcn)
-            ->will($this->returnValue($tmpFile));
+            ->will(self::returnValue($tmpFile));
 
         mkdir($tmpFile);
 
@@ -129,10 +129,10 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         $fqcn      = $namespace . '\\' . $className;
 
         $locator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('getProxyFileName')
             ->with($fqcn)
-            ->will($this->returnValue($tmpFile));
+            ->will(self::returnValue($tmpFile));
 
         mkdir($tmpFile);
 
@@ -143,7 +143,7 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
         } catch (FileNotWritableException $exception) {
             rmdir($tmpFile);
 
-            $this->assertEquals(['.', '..'], scandir($tmpDirPath));
+            self::assertEquals(['.', '..'], scandir($tmpDirPath));
         }
     }
 }

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -88,7 +88,7 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
             ->with($fqcn)
             ->will(self::returnValue($tmpFile));
 
-        $this->setExpectedException(FileNotWritableException::class);
+        $this->expectException(FileNotWritableException::class);
         $generator->generate(new ClassGenerator($fqcn));
     }
 
@@ -110,7 +110,7 @@ class FileWriterGeneratorStrategyTest extends PHPUnit_Framework_TestCase
 
         mkdir($tmpFile);
 
-        $this->setExpectedException(FileNotWritableException::class);
+        $this->expectException(FileNotWritableException::class);
         $generator->generate(new ClassGenerator($fqcn));
     }
 

--- a/tests/ProxyManagerTest/Inflector/ClassNameInflectorTest.php
+++ b/tests/ProxyManagerTest/Inflector/ClassNameInflectorTest.php
@@ -49,12 +49,12 @@ class ClassNameInflectorTest extends PHPUnit_Framework_TestCase
     {
         $inflector = new ClassNameInflector('ProxyNS');
 
-        $this->assertFalse($inflector->isProxyClassName($realClassName));
-        $this->assertTrue($inflector->isProxyClassName($proxyClassName));
-        $this->assertStringMatchesFormat($realClassName, $inflector->getUserClassName($realClassName));
-        $this->assertStringMatchesFormat($proxyClassName, $inflector->getProxyClassName($proxyClassName));
-        $this->assertStringMatchesFormat($proxyClassName, $inflector->getProxyClassName($realClassName));
-        $this->assertStringMatchesFormat($realClassName, $inflector->getUserClassName($proxyClassName));
+        self::assertFalse($inflector->isProxyClassName($realClassName));
+        self::assertTrue($inflector->isProxyClassName($proxyClassName));
+        self::assertStringMatchesFormat($realClassName, $inflector->getUserClassName($realClassName));
+        self::assertStringMatchesFormat($proxyClassName, $inflector->getProxyClassName($proxyClassName));
+        self::assertStringMatchesFormat($proxyClassName, $inflector->getProxyClassName($realClassName));
+        self::assertStringMatchesFormat($realClassName, $inflector->getUserClassName($proxyClassName));
     }
 
     /**
@@ -64,12 +64,12 @@ class ClassNameInflectorTest extends PHPUnit_Framework_TestCase
     {
         $inflector = new ClassNameInflector('ProxyNS');
 
-        $this->assertSame($inflector->getProxyClassName('Foo\\Bar'), $inflector->getProxyClassName('Foo\\Bar'));
-        $this->assertSame(
+        self::assertSame($inflector->getProxyClassName('Foo\\Bar'), $inflector->getProxyClassName('Foo\\Bar'));
+        self::assertSame(
             $inflector->getProxyClassName('Foo\\Bar', ['baz' => 'tab']),
             $inflector->getProxyClassName('Foo\\Bar', ['baz' => 'tab'])
         );
-        $this->assertSame(
+        self::assertSame(
             $inflector->getProxyClassName('Foo\\Bar', ['tab' => 'baz']),
             $inflector->getProxyClassName('Foo\\Bar', ['tab' => 'baz'])
         );
@@ -82,19 +82,19 @@ class ClassNameInflectorTest extends PHPUnit_Framework_TestCase
     {
         $inflector = new ClassNameInflector('ProxyNS');
 
-        $this->assertNotSame(
+        self::assertNotSame(
             $inflector->getProxyClassName('Foo\\Bar'),
             $inflector->getProxyClassName('Foo\\Bar', ['foo' => 'bar'])
         );
-        $this->assertNotSame(
+        self::assertNotSame(
             $inflector->getProxyClassName('Foo\\Bar', ['baz' => 'tab']),
             $inflector->getProxyClassName('Foo\\Bar', ['tab' => 'baz'])
         );
-        $this->assertNotSame(
+        self::assertNotSame(
             $inflector->getProxyClassName('Foo\\Bar', ['foo' => 'bar', 'tab' => 'baz']),
             $inflector->getProxyClassName('Foo\\Bar', ['foo' => 'bar'])
         );
-        $this->assertNotSame(
+        self::assertNotSame(
             $inflector->getProxyClassName('Foo\\Bar', ['foo' => 'bar', 'tab' => 'baz']),
             $inflector->getProxyClassName('Foo\\Bar', ['tab' => 'baz', 'foo' => 'bar'])
         );
@@ -107,7 +107,7 @@ class ClassNameInflectorTest extends PHPUnit_Framework_TestCase
     {
         $inflector = new ClassNameInflector('ProxyNS');
 
-        $this->assertSame(
+        self::assertSame(
             $inflector->getProxyClassName('\\Foo\\Bar', ['tab' => 'baz']),
             $inflector->getProxyClassName('Foo\\Bar', ['tab' => 'baz'])
         );
@@ -125,7 +125,7 @@ class ClassNameInflectorTest extends PHPUnit_Framework_TestCase
     {
         $inflector = new ClassNameInflector('ProxyNS');
 
-        $this->assertRegExp(
+        self::assertRegExp(
             '/([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)*/',
             $inflector->getProxyClassName($className, $parameters),
             'Class name string is a valid class identifier'

--- a/tests/ProxyManagerTest/Inflector/Util/ParameterEncoderTest.php
+++ b/tests/ProxyManagerTest/Inflector/Util/ParameterEncoderTest.php
@@ -44,7 +44,7 @@ class ParameterEncoderTest extends PHPUnit_Framework_TestCase
     {
         $encoder = new ParameterEncoder();
 
-        $this->assertRegExp(
+        self::assertRegExp(
             '/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+/',
             $encoder->encodeParameters($parameters),
             'Encoded string is a valid class identifier'

--- a/tests/ProxyManagerTest/Inflector/Util/ParameterHasherTest.php
+++ b/tests/ProxyManagerTest/Inflector/Util/ParameterHasherTest.php
@@ -45,7 +45,7 @@ class ParameterHasherTest extends PHPUnit_Framework_TestCase
     {
         $encoder = new ParameterHasher();
 
-        $this->assertSame($expectedHash, $encoder->hashParameters($parameters));
+        self::assertSame($expectedHash, $encoder->hashParameters($parameters));
     }
 
     /**

--- a/tests/ProxyManagerTest/ProxyGenerator/AbstractProxyGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AbstractProxyGeneratorTest.php
@@ -66,15 +66,15 @@ abstract class AbstractProxyGeneratorTest extends PHPUnit_Framework_TestCase
         $generatedReflection = new ReflectionClass($generatedClassName);
 
         if ($originalClass->isInterface()) {
-            $this->assertTrue($generatedReflection->implementsInterface($className));
+            self::assertTrue($generatedReflection->implementsInterface($className));
         } else {
-            $this->assertSame($originalClass->getName(), $generatedReflection->getParentClass()->getName());
+            self::assertSame($originalClass->getName(), $generatedReflection->getParentClass()->getName());
         }
 
-        $this->assertSame($generatedClassName, $generatedReflection->getName());
+        self::assertSame($generatedClassName, $generatedReflection->getName());
 
         foreach ($this->getExpectedImplementedInterfaces() as $interface) {
-            $this->assertTrue($generatedReflection->implementsInterface($interface));
+            self::assertTrue($generatedReflection->implementsInterface($interface));
         }
     }
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/MagicWakeupTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/MagicWakeupTest.php
@@ -47,18 +47,18 @@ class MagicWakeupTest extends PHPUnit_Framework_TestCase
 
         $magicWakeup = new MagicWakeup($reflection);
 
-        $this->assertSame('__wakeup', $magicWakeup->getName());
-        $this->assertCount(0, $magicWakeup->getParameters());
-        $this->assertSame("unset(\$this->bar, \$this->baz);\n\n", $magicWakeup->getBody());
+        self::assertSame('__wakeup', $magicWakeup->getName());
+        self::assertCount(0, $magicWakeup->getParameters());
+        self::assertSame("unset(\$this->bar, \$this->baz);\n\n", $magicWakeup->getBody());
     }
 
     public function testBodyStructureWithoutPublicProperties()
     {
         $magicWakeup = new MagicWakeup(new ReflectionClass(EmptyClass::class));
 
-        $this->assertSame('__wakeup', $magicWakeup->getName());
-        $this->assertCount(0, $magicWakeup->getParameters());
-        $this->assertEmpty($magicWakeup->getBody());
+        self::assertSame('__wakeup', $magicWakeup->getName());
+        self::assertCount(0, $magicWakeup->getParameters());
+        self::assertEmpty($magicWakeup->getBody());
     }
 
     /**

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodPrefixInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodPrefixInterceptorTest.php
@@ -42,12 +42,12 @@ class SetMethodPrefixInterceptorTest extends PHPUnit_Framework_TestCase
         /* @var $suffix PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffix = $this->getMock(PropertyGenerator::class);
 
-        $suffix->expects($this->once())->method('getName')->will($this->returnValue('foo'));
+        $suffix->expects(self::once())->method('getName')->will(self::returnValue('foo'));
 
         $setter = new SetMethodPrefixInterceptor($suffix);
 
-        $this->assertSame('setMethodPrefixInterceptor', $setter->getName());
-        $this->assertCount(2, $setter->getParameters());
-        $this->assertSame('$this->foo[$methodName] = $prefixInterceptor;', $setter->getBody());
+        self::assertSame('setMethodPrefixInterceptor', $setter->getName());
+        self::assertCount(2, $setter->getParameters());
+        self::assertSame('$this->foo[$methodName] = $prefixInterceptor;', $setter->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodSuffixInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodSuffixInterceptorTest.php
@@ -42,12 +42,12 @@ class SetMethodSuffixInterceptorTest extends PHPUnit_Framework_TestCase
         /* @var $suffix PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffix = $this->getMock(PropertyGenerator::class);
 
-        $suffix->expects($this->once())->method('getName')->will($this->returnValue('foo'));
+        $suffix->expects(self::once())->method('getName')->will(self::returnValue('foo'));
 
         $setter = new SetMethodSuffixInterceptor($suffix);
 
-        $this->assertSame('setMethodSuffixInterceptor', $setter->getName());
-        $this->assertCount(2, $setter->getParameters());
-        $this->assertSame('$this->foo[$methodName] = $suffixInterceptor;', $setter->getBody());
+        self::assertSame('setMethodSuffixInterceptor', $setter->getName());
+        self::assertCount(2, $setter->getParameters());
+        self::assertSame('$this->foo[$methodName] = $suffixInterceptor;', $setter->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyPropertiesTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyPropertiesTest.php
@@ -57,8 +57,8 @@ class BindProxyPropertiesTest extends PHPUnit_Framework_TestCase
         $this->prefixInterceptors = $this->getMock(PropertyGenerator::class);
         $this->suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $this->prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $this->suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $this->prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $this->suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
     }
 
     public function testSignature()
@@ -68,20 +68,20 @@ class BindProxyPropertiesTest extends PHPUnit_Framework_TestCase
             $this->prefixInterceptors,
             $this->suffixInterceptors
         );
-        $this->assertSame('bindProxyProperties', $method->getName());
-        $this->assertSame('private', $method->getVisibility());
-        $this->assertFalse($method->isStatic());
+        self::assertSame('bindProxyProperties', $method->getName());
+        self::assertSame('private', $method->getVisibility());
+        self::assertFalse($method->isStatic());
 
         $parameters = $method->getParameters();
 
-        $this->assertCount(3, $parameters);
+        self::assertCount(3, $parameters);
 
-        $this->assertSame(
+        self::assertSame(
             ClassWithProtectedProperties::class,
             $parameters['localizedObject']->getType()
         );
-        $this->assertSame('array', $parameters['prefixInterceptors']->getType());
-        $this->assertSame('array', $parameters['suffixInterceptors']->getType());
+        self::assertSame('array', $parameters['prefixInterceptors']->getType());
+        self::assertSame('array', $parameters['suffixInterceptors']->getType());
     }
 
     public function testBodyStructure()
@@ -121,7 +121,7 @@ $this->pre = $prefixInterceptors;
 $this->post = $suffixInterceptors;
 PHP;
 
-        $this->assertSame($expectedCode, $method->getBody());
+        self::assertSame($expectedCode, $method->getBody());
     }
 
     public function testBodyStructureWithProtectedProperties()
@@ -132,7 +132,7 @@ PHP;
             $this->suffixInterceptors
         );
 
-        $this->assertSame(
+        self::assertSame(
             '$this->property0 = & $localizedObject->property0;
 
 $this->property1 = & $localizedObject->property1;
@@ -167,7 +167,7 @@ $this->post = $suffixInterceptors;',
             $this->suffixInterceptors
         );
 
-        $this->assertSame(
+        self::assertSame(
             '\Closure::bind(function () use ($localizedObject) {
     $this->property0 = & $localizedObject->property0;
 }, $this, \'ProxyManagerTestAsset\\\\ClassWithPrivateProperties\')->__invoke();

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethodTest.php
@@ -56,8 +56,8 @@ class InterceptedMethodTest extends PHPUnit_Framework_TestCase
         $this->prefixInterceptors = $this->getMock(PropertyGenerator::class);
         $this->suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $this->prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $this->suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $this->prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $this->suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
     }
 
     public function testBodyStructure()
@@ -68,11 +68,11 @@ class InterceptedMethodTest extends PHPUnit_Framework_TestCase
             $this->suffixInterceptors
         );
 
-        $this->assertInstanceOf(MethodGenerator::class, $method);
+        self::assertInstanceOf(MethodGenerator::class, $method);
 
-        $this->assertSame('publicByReferenceParameterMethod', $method->getName());
-        $this->assertCount(2, $method->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('publicByReferenceParameterMethod', $method->getName());
+        self::assertCount(2, $method->getParameters());
+        self::assertStringMatchesFormat(
             '%a$returnValue = parent::publicByReferenceParameterMethod($param, $byRefParam);%A',
             $method->getBody()
         );
@@ -86,11 +86,11 @@ class InterceptedMethodTest extends PHPUnit_Framework_TestCase
             $this->suffixInterceptors
         );
 
-        $this->assertInstanceOf(MethodGenerator::class, $method);
+        self::assertInstanceOf(MethodGenerator::class, $method);
 
-        $this->assertSame('foo', $method->getName());
-        $this->assertCount(2, $method->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('foo', $method->getName());
+        self::assertCount(2, $method->getParameters());
+        self::assertStringMatchesFormat(
             '%a$returnValue = parent::foo($bar, ...$baz);%A',
             $method->getBody()
         );

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicCloneTest.php
@@ -48,14 +48,14 @@ class MagicCloneTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicClone = new MagicClone($reflection, $prefixInterceptors, $suffixInterceptors);
 
-        $this->assertSame('__clone', $magicClone->getName());
-        $this->assertCount(0, $magicClone->getParameters());
-        $this->assertStringMatchesFormat("%a\n\n\$returnValue = null;\n\n%a", $magicClone->getBody());
+        self::assertSame('__clone', $magicClone->getName());
+        self::assertCount(0, $magicClone->getParameters());
+        self::assertStringMatchesFormat("%a\n\n\$returnValue = null;\n\n%a", $magicClone->getBody());
     }
 
     /**
@@ -69,13 +69,13 @@ class MagicCloneTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicClone = new MagicClone($reflection, $prefixInterceptors, $suffixInterceptors);
 
-        $this->assertSame('__clone', $magicClone->getName());
-        $this->assertCount(0, $magicClone->getParameters());
-        $this->assertStringMatchesFormat("%a\n\n\$returnValue = parent::__clone();\n\n%a", $magicClone->getBody());
+        self::assertSame('__clone', $magicClone->getName());
+        self::assertCount(0, $magicClone->getParameters());
+        self::assertStringMatchesFormat("%a\n\n\$returnValue = parent::__clone();\n\n%a", $magicClone->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGetTest.php
@@ -48,8 +48,8 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicGet = new MagicGet(
             $reflection,
@@ -57,9 +57,9 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__get', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = & $accessor();%a', $magicGet->getBody());
+        self::assertSame('__get', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = & $accessor();%a', $magicGet->getBody());
     }
 
     /**
@@ -73,8 +73,8 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicGet = new MagicGet(
             $reflection,
@@ -82,8 +82,8 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__get', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = & parent::__get($name);%a', $magicGet->getBody());
+        self::assertSame('__get', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = & parent::__get($name);%a', $magicGet->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIssetTest.php
@@ -48,8 +48,8 @@ class MagicIssetTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicIsset = new MagicIsset(
             $reflection,
@@ -57,9 +57,9 @@ class MagicIssetTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__isset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = $accessor();%a', $magicIsset->getBody());
+        self::assertSame('__isset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = $accessor();%a', $magicIsset->getBody());
     }
 
     /**
@@ -73,8 +73,8 @@ class MagicIssetTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicIsset = new MagicIsset(
             $reflection,
@@ -82,8 +82,8 @@ class MagicIssetTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__isset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = & parent::__isset($name);%a', $magicIsset->getBody());
+        self::assertSame('__isset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = & parent::__isset($name);%a', $magicIsset->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSetTest.php
@@ -48,8 +48,8 @@ class MagicSetTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicGet = new MagicSet(
             $reflection,
@@ -57,9 +57,9 @@ class MagicSetTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__set', $magicGet->getName());
-        $this->assertCount(2, $magicGet->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = & $accessor();%a', $magicGet->getBody());
+        self::assertSame('__set', $magicGet->getName());
+        self::assertCount(2, $magicGet->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = & $accessor();%a', $magicGet->getBody());
     }
 
     /**
@@ -73,8 +73,8 @@ class MagicSetTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicGet = new MagicSet(
             $reflection,
@@ -82,8 +82,8 @@ class MagicSetTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__set', $magicGet->getName());
-        $this->assertCount(2, $magicGet->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = & parent::__set($name, $value);%a', $magicGet->getBody());
+        self::assertSame('__set', $magicGet->getName());
+        self::assertCount(2, $magicGet->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = & parent::__set($name, $value);%a', $magicGet->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSleepTest.php
@@ -48,8 +48,8 @@ class MagicSleepTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicGet = new MagicSleep(
             $reflection,
@@ -57,9 +57,9 @@ class MagicSleepTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__sleep', $magicGet->getName());
-        $this->assertEmpty($magicGet->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = array_keys((array) $this);%a', $magicGet->getBody());
+        self::assertSame('__sleep', $magicGet->getName());
+        self::assertEmpty($magicGet->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = array_keys((array) $this);%a', $magicGet->getBody());
     }
 
     /**
@@ -73,8 +73,8 @@ class MagicSleepTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicGet = new MagicSleep(
             $reflection,
@@ -82,8 +82,8 @@ class MagicSleepTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__sleep', $magicGet->getName());
-        $this->assertEmpty($magicGet->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = & parent::__sleep();%a', $magicGet->getBody());
+        self::assertSame('__sleep', $magicGet->getName());
+        self::assertEmpty($magicGet->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = & parent::__sleep();%a', $magicGet->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnsetTest.php
@@ -48,8 +48,8 @@ class MagicUnsetTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicGet = new MagicUnset(
             $reflection,
@@ -57,9 +57,9 @@ class MagicUnsetTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__unset', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = $accessor();%a', $magicGet->getBody());
+        self::assertSame('__unset', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = $accessor();%a', $magicGet->getBody());
     }
 
     /**
@@ -73,8 +73,8 @@ class MagicUnsetTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicGet = new MagicUnset(
             $reflection,
@@ -82,8 +82,8 @@ class MagicUnsetTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('__unset', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat('%a$returnValue = & parent::__unset($name);%a', $magicGet->getBody());
+        self::assertSame('__unset', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat('%a$returnValue = & parent::__unset($name);%a', $magicGet->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/StaticProxyConstructorTest.php
@@ -45,8 +45,8 @@ class StaticProxyConstructorTest extends PHPUnit_Framework_TestCase
         $this->prefixInterceptors = $this->getMock(PropertyGenerator::class);
         $this->suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $this->prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $this->suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $this->prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $this->suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
     }
 
     public function testSignature()
@@ -56,18 +56,18 @@ class StaticProxyConstructorTest extends PHPUnit_Framework_TestCase
             $this->prefixInterceptors,
             $this->suffixInterceptors
         );
-        $this->assertSame('staticProxyConstructor', $method->getName());
+        self::assertSame('staticProxyConstructor', $method->getName());
 
         $parameters = $method->getParameters();
 
-        $this->assertCount(3, $parameters);
+        self::assertCount(3, $parameters);
 
-        $this->assertSame(
+        self::assertSame(
             ClassWithProtectedProperties::class,
             $parameters['localizedObject']->getType()
         );
-        $this->assertSame('array', $parameters['prefixInterceptors']->getType());
-        $this->assertSame('array', $parameters['suffixInterceptors']->getType());
+        self::assertSame('array', $parameters['prefixInterceptors']->getType());
+        self::assertSame('array', $parameters['suffixInterceptors']->getType());
     }
 
     public function testBodyStructure()
@@ -78,7 +78,7 @@ class StaticProxyConstructorTest extends PHPUnit_Framework_TestCase
             $this->suffixInterceptors
         );
 
-        $this->assertSame(
+        self::assertSame(
             'static $reflection;
 
 $reflection = $reflection ?: $reflection = new \ReflectionClass(__CLASS__);

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/Util/InterceptorGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/Util/InterceptorGeneratorTest.php
@@ -52,12 +52,12 @@ class InterceptorGeneratorTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $bar->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $baz->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $method->expects($this->any())->method('getName')->will($this->returnValue('fooMethod'));
-        $method->expects($this->any())->method('getParameters')->will($this->returnValue([$bar, $baz]));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $bar->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $baz->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $method->expects(self::any())->method('getName')->will(self::returnValue('fooMethod'));
+        $method->expects(self::any())->method('getParameters')->will(self::returnValue([$bar, $baz]));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $body = InterceptorGenerator::createInterceptedMethodBody(
             '$returnValue = "foo";',
@@ -66,7 +66,7 @@ class InterceptorGeneratorTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame(
+        self::assertSame(
             'if (isset($this->pre[\'fooMethod\'])) {' . "\n"
             . '    $returnEarly       = false;' . "\n"
             . '    $prefixReturnValue = $this->pre[\'fooMethod\']->__invoke($this, $this, \'fooMethod\', '

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizerTest.php
@@ -48,7 +48,7 @@ class AccessInterceptorScopeLocalizerTest extends AbstractProxyGeneratorTest
 
         if ($reflectionClass->isInterface()) {
             // @todo interfaces *may* be proxied by deferring property localization to the constructor (no hardcoding)
-            $this->setExpectedException(InvalidProxiedClassException::class);
+            $this->expectException(InvalidProxiedClassException::class);
         }
 
         parent::testGeneratesValidCode($className);

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethodTest.php
@@ -47,9 +47,9 @@ class InterceptedMethodTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $method = InterceptedMethod::generateMethod(
             new MethodReflection(BaseClass::class, 'publicByReferenceParameterMethod'),
@@ -58,11 +58,11 @@ class InterceptedMethodTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertInstanceOf(MethodGenerator::class, $method);
+        self::assertInstanceOf(MethodGenerator::class, $method);
 
-        $this->assertSame('publicByReferenceParameterMethod', $method->getName());
-        $this->assertCount(2, $method->getParameters());
-        $this->assertGreaterThan(
+        self::assertSame('publicByReferenceParameterMethod', $method->getName());
+        self::assertCount(2, $method->getParameters());
+        self::assertGreaterThan(
             0,
             strpos(
                 $method->getBody(),

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicCloneTest.php
@@ -49,15 +49,15 @@ class MagicCloneTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $magicClone = new MagicClone($reflection, $valueHolder, $prefixInterceptors, $suffixInterceptors);
 
-        $this->assertSame('__clone', $magicClone->getName());
-        $this->assertCount(0, $magicClone->getParameters());
-        $this->assertSame(
+        self::assertSame('__clone', $magicClone->getName());
+        self::assertCount(0, $magicClone->getParameters());
+        self::assertSame(
             '$this->bar = clone $this->bar;' . "\n\n"
             . 'foreach ($this->pre as $key => $value) {' . "\n"
             . '    $this->pre[$key] = clone $value;' . "\n"

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGetTest.php
@@ -55,10 +55,10 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
-        $publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
 
         $magicGet = new MagicGet(
             $reflection,
@@ -68,8 +68,8 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
             $publicProperties
         );
 
-        $this->assertSame('__get', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat('%A$returnValue = & $this->bar->$name;%A', $magicGet->getBody());
+        self::assertSame('__get', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat('%A$returnValue = & $this->bar->$name;%A', $magicGet->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIssetTest.php
@@ -55,10 +55,10 @@ class MagicIssetTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
-        $publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
 
         $magicIsset = new MagicIsset(
             $reflection,
@@ -68,8 +68,8 @@ class MagicIssetTest extends PHPUnit_Framework_TestCase
             $publicProperties
         );
 
-        $this->assertSame('__isset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
-        $this->assertGreaterThan(0, strpos($magicIsset->getBody(), '$returnValue = isset($this->bar->$name);'));
+        self::assertSame('__isset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
+        self::assertGreaterThan(0, strpos($magicIsset->getBody(), '$returnValue = isset($this->bar->$name);'));
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSetTest.php
@@ -55,10 +55,10 @@ class MagicSetTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
-        $publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
 
         $magicSet = new MagicSet(
             $reflection,
@@ -68,8 +68,8 @@ class MagicSetTest extends PHPUnit_Framework_TestCase
             $publicProperties
         );
 
-        $this->assertSame('__set', $magicSet->getName());
-        $this->assertCount(2, $magicSet->getParameters());
-        $this->assertGreaterThan(0, strpos($magicSet->getBody(), '$returnValue = ($this->bar->$name = $value);'));
+        self::assertSame('__set', $magicSet->getName());
+        self::assertCount(2, $magicSet->getParameters());
+        self::assertGreaterThan(0, strpos($magicSet->getBody(), '$returnValue = ($this->bar->$name = $value);'));
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnsetTest.php
@@ -55,10 +55,10 @@ class MagicUnsetTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
-        $publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
 
         $magicUnset = new MagicUnset(
             $reflection,
@@ -68,9 +68,9 @@ class MagicUnsetTest extends PHPUnit_Framework_TestCase
             $publicProperties
         );
 
-        $this->assertSame('__unset', $magicUnset->getName());
-        $this->assertCount(1, $magicUnset->getParameters());
-        $this->assertGreaterThan(
+        self::assertSame('__unset', $magicUnset->getName());
+        self::assertCount(1, $magicUnset->getParameters());
+        self::assertGreaterThan(
             0,
             strpos($magicUnset->getBody(), 'unset($this->bar->$name);')
         );

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/StaticProxyConstructorTest.php
@@ -48,9 +48,9 @@ class StaticProxyConstructorTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $constructor = new StaticProxyConstructor(
             new ReflectionClass(
@@ -61,9 +61,9 @@ class StaticProxyConstructorTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame('staticProxyConstructor', $constructor->getName());
-        $this->assertCount(3, $constructor->getParameters());
-        $this->assertSame(
+        self::assertSame('staticProxyConstructor', $constructor->getName());
+        self::assertCount(3, $constructor->getParameters());
+        self::assertSame(
             'static $reflection;
 
 $reflection = $reflection ?: $reflection = new \ReflectionClass(__CLASS__);
@@ -89,9 +89,9 @@ return $instance;',
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $constructor = new StaticProxyConstructor(
             new ReflectionClass(EmptyClass::class),
@@ -100,9 +100,9 @@ return $instance;',
             $suffixInterceptors
         );
 
-        $this->assertSame('staticProxyConstructor', $constructor->getName());
-        $this->assertCount(3, $constructor->getParameters());
-        $this->assertSame(
+        self::assertSame('staticProxyConstructor', $constructor->getName());
+        self::assertCount(3, $constructor->getParameters());
+        self::assertSame(
             'static $reflection;
 
 $reflection = $reflection ?: $reflection = new \ReflectionClass(__CLASS__);
@@ -129,9 +129,9 @@ return $instance;',
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $constructor = new StaticProxyConstructor(
             new ReflectionClass(ClassWithMixedProperties::class),

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/Util/InterceptorGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/Util/InterceptorGeneratorTest.php
@@ -54,13 +54,13 @@ class InterceptorGeneratorTest extends PHPUnit_Framework_TestCase
         /* @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $suffixInterceptors = $this->getMock(PropertyGenerator::class);
 
-        $bar->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $baz->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $method->expects($this->any())->method('getName')->will($this->returnValue('fooMethod'));
-        $method->expects($this->any())->method('getParameters')->will($this->returnValue([$bar, $baz]));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $prefixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('pre'));
-        $suffixInterceptors->expects($this->any())->method('getName')->will($this->returnValue('post'));
+        $bar->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $baz->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $method->expects(self::any())->method('getName')->will(self::returnValue('fooMethod'));
+        $method->expects(self::any())->method('getParameters')->will(self::returnValue([$bar, $baz]));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
+        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
 
         $body = InterceptorGenerator::createInterceptedMethodBody(
             '$returnValue = "foo";',
@@ -70,7 +70,7 @@ class InterceptorGeneratorTest extends PHPUnit_Framework_TestCase
             $suffixInterceptors
         );
 
-        $this->assertSame(
+        self::assertSame(
             'if (isset($this->pre[\'fooMethod\'])) {' . "\n"
             . '    $returnEarly       = false;' . "\n"
             . '    $prefixReturnValue = $this->pre[\'fooMethod\']->__invoke($this, $this->foo, \'fooMethod\', '

--- a/tests/ProxyManagerTest/ProxyGenerator/Assertion/CanProxyAssertionTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Assertion/CanProxyAssertionTest.php
@@ -79,7 +79,7 @@ class CanProxyAssertionTest extends PHPUnit_Framework_TestCase
             BaseInterface::class
         ));
 
-        $this->assertTrue(true); // not nice, but assertions are just fail-checks, no real code executed
+        self::assertTrue(true); // not nice, but assertions are just fail-checks, no real code executed
     }
 
     public function testDeniesInterfaceIfSpecified()
@@ -100,7 +100,7 @@ class CanProxyAssertionTest extends PHPUnit_Framework_TestCase
     {
         CanProxyAssertion::assertClassCanBeProxied(new ReflectionClass($className));
 
-        $this->assertTrue(true); // not nice, but assertions are just fail-checks, no real code executed
+        self::assertTrue(true); // not nice, but assertions are just fail-checks, no real code executed
     }
 
     public function testDisallowsConstructor()

--- a/tests/ProxyManagerTest/ProxyGenerator/Assertion/CanProxyAssertionTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Assertion/CanProxyAssertionTest.php
@@ -59,14 +59,14 @@ class CanProxyAssertionTest extends PHPUnit_Framework_TestCase
 {
     public function testDeniesFinalClasses()
     {
-        $this->setExpectedException(InvalidProxiedClassException::class);
+        $this->expectException(InvalidProxiedClassException::class);
 
         CanProxyAssertion::assertClassCanBeProxied(new ReflectionClass(FinalClass::class));
     }
 
     public function testDeniesClassesWithAbstractProtectedMethods()
     {
-        $this->setExpectedException(InvalidProxiedClassException::class);
+        $this->expectException(InvalidProxiedClassException::class);
 
         CanProxyAssertion::assertClassCanBeProxied(new ReflectionClass(
             ClassWithAbstractProtectedMethod::class
@@ -86,7 +86,7 @@ class CanProxyAssertionTest extends PHPUnit_Framework_TestCase
     {
         CanProxyAssertion::assertClassCanBeProxied(new ReflectionClass(BaseClass::class), false);
 
-        $this->setExpectedException(InvalidProxiedClassException::class);
+        $this->expectException(InvalidProxiedClassException::class);
 
         CanProxyAssertion::assertClassCanBeProxied(new ReflectionClass(BaseInterface::class), false);
     }
@@ -105,7 +105,7 @@ class CanProxyAssertionTest extends PHPUnit_Framework_TestCase
 
     public function testDisallowsConstructor()
     {
-        $this->setExpectedException(BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         new CanProxyAssertion();
     }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoading/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoading/MethodGenerator/StaticProxyConstructorTest.php
@@ -43,17 +43,17 @@ class StaticProxyConstructorTest extends PHPUnit_Framework_TestCase
         /* @var $initializer PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initializer = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $constructor = new StaticProxyConstructor(
             $initializer,
             Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedProperties::class))
         );
 
-        $this->assertSame('staticProxyConstructor', $constructor->getName());
-        $this->assertCount(1, $constructor->getParameters());
+        self::assertSame('staticProxyConstructor', $constructor->getName());
+        self::assertCount(1, $constructor->getParameters());
 
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             'static $reflection;
 
 $reflection = $reflection ?: $reflection = new \ReflectionClass(__CLASS__);

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
@@ -47,8 +47,8 @@ class CallInitializerTest extends PHPUnit_Framework_TestCase
         /* @var $initializationTracker PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initializationTracker = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('init'));
-        $initializationTracker->expects($this->any())->method('getName')->will($this->returnValue('track'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('init'));
+        $initializationTracker->expects(self::any())->method('getName')->will(self::returnValue('track'));
 
         $callInitializer = new CallInitializer(
             $initializer,
@@ -110,7 +110,7 @@ $this->track = false;
 
 return $result;';
 
-        $this->assertSame(
+        self::assertSame(
             $expectedCode,
             $callInitializer->getBody()
         );

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/GetProxyInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/GetProxyInitializerTest.php
@@ -42,12 +42,12 @@ class GetProxyInitializerTest extends PHPUnit_Framework_TestCase
         /* @var $initializer PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initializer = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $getter = new GetProxyInitializer($initializer);
 
-        $this->assertSame('getProxyInitializer', $getter->getName());
-        $this->assertCount(0, $getter->getParameters());
-        $this->assertSame('return $this->foo;', $getter->getBody());
+        self::assertSame('getProxyInitializer', $getter->getName());
+        self::assertCount(0, $getter->getParameters());
+        self::assertSame('return $this->foo;', $getter->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/InitializeProxyTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/InitializeProxyTest.php
@@ -45,14 +45,14 @@ class InitializeProxyTest extends PHPUnit_Framework_TestCase
         /* @var $initCall MethodGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initCall    = $this->getMock(MethodGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $initCall->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initCall->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $initializeProxy = new InitializeProxy($initializer, $initCall);
 
-        $this->assertSame('initializeProxy', $initializeProxy->getName());
-        $this->assertCount(0, $initializeProxy->getParameters());
-        $this->assertSame(
+        self::assertSame('initializeProxy', $initializeProxy->getName());
+        self::assertCount(0, $initializeProxy->getParameters());
+        self::assertSame(
             'return $this->foo && $this->bar(\'initializeProxy\', []);',
             $initializeProxy->getBody()
         );

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/IsProxyInitializedTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/IsProxyInitializedTest.php
@@ -42,13 +42,13 @@ class IsProxyInitializedTest extends PHPUnit_Framework_TestCase
         /* @var $initializer PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initializer = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $isProxyInitialized = new IsProxyInitialized($initializer);
 
-        $this->assertSame('isProxyInitialized', $isProxyInitialized->getName());
-        $this->assertCount(0, $isProxyInitialized->getParameters());
-        $this->assertSame('return ! $this->foo;', $isProxyInitialized->getBody());
+        self::assertSame('isProxyInitialized', $isProxyInitialized->getName());
+        self::assertCount(0, $isProxyInitialized->getParameters());
+        self::assertSame('return ! $this->foo;', $isProxyInitialized->getBody());
         self::assertStringMatchesFormat('%A : bool%A', $isProxyInitialized->generate(), 'Return type hint is boolean');
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicCloneTest.php
@@ -48,14 +48,14 @@ class MagicCloneTest extends PHPUnit_Framework_TestCase
         /* @var $initCall MethodGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initCall    = $this->getMock(MethodGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $initCall->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initCall->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicClone = new MagicClone($reflection, $initializer, $initCall);
 
-        $this->assertSame('__clone', $magicClone->getName());
-        $this->assertCount(0, $magicClone->getParameters());
-        $this->assertSame(
+        self::assertSame('__clone', $magicClone->getName());
+        self::assertCount(0, $magicClone->getParameters());
+        self::assertSame(
             "\$this->foo && \$this->bar('__clone', []);",
             $magicClone->getBody()
         );

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
@@ -161,13 +161,13 @@ PHP;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $this->initMethod->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $this->publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
-        $this->publicProperties->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $this->protectedProperties->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $this->privateProperties->expects($this->any())->method('getName')->will($this->returnValue('tab'));
-        $this->initializationTracker->expects($this->any())->method('getName')->will($this->returnValue('init'));
+        $this->initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $this->initMethod->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $this->publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $this->publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $this->protectedProperties->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $this->privateProperties->expects(self::any())->method('getName')->will(self::returnValue('tab'));
+        $this->initializationTracker->expects(self::any())->method('getName')->will(self::returnValue('init'));
     }
 
     /**
@@ -185,10 +185,10 @@ PHP;
             $this->initializationTracker
         );
 
-        $this->assertSame('__get', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
+        self::assertSame('__get', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
 
-        $this->assertStringMatchesFormat($this->expectedCode, $magicGet->getBody());
+        self::assertStringMatchesFormat($this->expectedCode, $magicGet->getBody());
     }
 
     /**
@@ -206,10 +206,10 @@ PHP;
             $this->initializationTracker
         );
 
-        $this->assertSame('__get', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
+        self::assertSame('__get', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
 
-        $this->assertStringMatchesFormat($this->expectedCode, $magicGet->getBody());
-        $this->assertStringMatchesFormat('%Areturn parent::__get($name);', $magicGet->getBody());
+        self::assertStringMatchesFormat($this->expectedCode, $magicGet->getBody());
+        self::assertStringMatchesFormat('%Areturn parent::__get($name);', $magicGet->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIssetTest.php
@@ -146,12 +146,12 @@ PHP;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $this->initMethod->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $this->publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
-        $this->publicProperties->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $this->protectedProperties->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $this->privateProperties->expects($this->any())->method('getName')->will($this->returnValue('tab'));
+        $this->initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $this->initMethod->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $this->publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $this->publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $this->protectedProperties->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $this->privateProperties->expects(self::any())->method('getName')->will(self::returnValue('tab'));
     }
 
     /**
@@ -168,10 +168,10 @@ PHP;
             $this->privateProperties
         );
 
-        $this->assertSame('__isset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
+        self::assertSame('__isset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
 
-        $this->assertStringMatchesFormat($this->expectedCode, $magicIsset->getBody());
+        self::assertStringMatchesFormat($this->expectedCode, $magicIsset->getBody());
     }
 
     /**
@@ -188,12 +188,12 @@ PHP;
             $this->privateProperties
         );
 
-        $this->assertSame('__isset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
+        self::assertSame('__isset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
 
         $body = $magicIsset->getBody();
 
-        $this->assertStringMatchesFormat($this->expectedCode, $body);
-        $this->assertStringMatchesFormat('%Areturn parent::__isset($name);', $body);
+        self::assertStringMatchesFormat($this->expectedCode, $body);
+        self::assertStringMatchesFormat('%Areturn parent::__isset($name);', $body);
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSetTest.php
@@ -147,12 +147,12 @@ PHP;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $this->initMethod->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $this->publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
-        $this->publicProperties->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $this->protectedProperties->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $this->privateProperties->expects($this->any())->method('getName')->will($this->returnValue('tab'));
+        $this->initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $this->initMethod->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $this->publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $this->publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $this->protectedProperties->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $this->privateProperties->expects(self::any())->method('getName')->will(self::returnValue('tab'));
     }
 
     /**
@@ -169,9 +169,9 @@ PHP;
             $this->privateProperties
         );
 
-        $this->assertSame('__set', $magicSet->getName());
-        $this->assertCount(2, $magicSet->getParameters());
-        $this->assertStringMatchesFormat($this->expectedCode, $magicSet->getBody());
+        self::assertSame('__set', $magicSet->getName());
+        self::assertCount(2, $magicSet->getParameters());
+        self::assertStringMatchesFormat($this->expectedCode, $magicSet->getBody());
     }
 
     /**
@@ -188,12 +188,12 @@ PHP;
             $this->privateProperties
         );
 
-        $this->assertSame('__set', $magicSet->getName());
-        $this->assertCount(2, $magicSet->getParameters());
+        self::assertSame('__set', $magicSet->getName());
+        self::assertCount(2, $magicSet->getParameters());
 
         $body = $magicSet->getBody();
 
-        $this->assertStringMatchesFormat($this->expectedCode, $body);
-        $this->assertStringMatchesFormat('%Areturn parent::__set($name, $value);', $body);
+        self::assertStringMatchesFormat($this->expectedCode, $body);
+        self::assertStringMatchesFormat('%Areturn parent::__set($name, $value);', $body);
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSleepTest.php
@@ -48,14 +48,14 @@ class MagicSleepTest extends PHPUnit_Framework_TestCase
         /* @var $initMethod MethodGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initMethod  = $this->getMock(MethodGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $initMethod->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initMethod->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicSleep = new MagicSleep($reflection, $initializer, $initMethod);
 
-        $this->assertSame('__sleep', $magicSleep->getName());
-        $this->assertCount(0, $magicSleep->getParameters());
-        $this->assertSame(
+        self::assertSame('__sleep', $magicSleep->getName());
+        self::assertCount(0, $magicSleep->getParameters());
+        self::assertSame(
             "\$this->foo && \$this->bar('__sleep', []);"
             . "\n\nreturn array_keys((array) \$this);",
             $magicSleep->getBody()

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnsetTest.php
@@ -152,12 +152,12 @@ PHP;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $this->initMethod->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $this->publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
-        $this->publicProperties->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $this->protectedProperties->expects($this->any())->method('getName')->will($this->returnValue('baz'));
-        $this->privateProperties->expects($this->any())->method('getName')->will($this->returnValue('tab'));
+        $this->initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $this->initMethod->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $this->publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $this->publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $this->protectedProperties->expects(self::any())->method('getName')->will(self::returnValue('baz'));
+        $this->privateProperties->expects(self::any())->method('getName')->will(self::returnValue('tab'));
     }
 
     /**
@@ -174,9 +174,9 @@ PHP;
             $this->privateProperties
         );
 
-        $this->assertSame('__unset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
-        $this->assertStringMatchesFormat($this->expectedCode, $magicIsset->getBody());
+        self::assertSame('__unset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
+        self::assertStringMatchesFormat($this->expectedCode, $magicIsset->getBody());
     }
 
     /**
@@ -193,12 +193,12 @@ PHP;
             $this->privateProperties
         );
 
-        $this->assertSame('__unset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
+        self::assertSame('__unset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
 
         $body = $magicIsset->getBody();
 
-        $this->assertStringMatchesFormat($this->expectedCode, $body);
-        $this->assertStringMatchesFormat('%Areturn parent::__unset($name);', $body);
+        self::assertStringMatchesFormat($this->expectedCode, $body);
+        self::assertStringMatchesFormat('%Areturn parent::__unset($name);', $body);
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/SetProxyInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/SetProxyInitializerTest.php
@@ -43,19 +43,19 @@ class SetProxyInitializerTest extends PHPUnit_Framework_TestCase
         /* @var $initializer PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initializer = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $setter     = new SetProxyInitializer($initializer);
         $parameters = $setter->getParameters();
 
-        $this->assertSame('setProxyInitializer', $setter->getName());
-        $this->assertCount(1, $parameters);
+        self::assertSame('setProxyInitializer', $setter->getName());
+        self::assertCount(1, $parameters);
 
         /* @var $initializer ParameterGenerator */
         $initializer = array_shift($parameters);
 
-        $this->assertInstanceOf(ParameterGenerator::class, $initializer);
-        $this->assertSame('initializer', $initializer->getName());
-        $this->assertSame('$this->foo = $initializer;', $setter->getBody());
+        self::assertInstanceOf(ParameterGenerator::class, $initializer);
+        self::assertSame('initializer', $initializer->getName());
+        self::assertSame('$this->foo = $initializer;', $setter->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/PrivatePropertiesMapTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/PrivatePropertiesMapTest.php
@@ -56,7 +56,7 @@ class PrivatePropertiesMapTest extends AbstractUniquePropertyNameTest
             Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedProperties::class))
         );
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'privateProperty0' => [
                     ClassWithMixedProperties::class => true,
@@ -78,14 +78,14 @@ class PrivatePropertiesMapTest extends AbstractUniquePropertyNameTest
             Properties::fromReflectionClass(new ReflectionClass(ClassWithAbstractProtectedMethod::class))
         );
 
-        $this->assertSame([], $map->getDefaultValue()->getValue());
+        self::assertSame([], $map->getDefaultValue()->getValue());
     }
 
     public function testIsStaticPrivate()
     {
         $map = $this->createProperty();
 
-        $this->assertTrue($map->isStatic());
-        $this->assertSame(ProtectedPropertiesMap::VISIBILITY_PRIVATE, $map->getVisibility());
+        self::assertTrue($map->isStatic());
+        self::assertSame(ProtectedPropertiesMap::VISIBILITY_PRIVATE, $map->getVisibility());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/ProtectedPropertiesMapTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/ProtectedPropertiesMapTest.php
@@ -55,7 +55,7 @@ class ProtectedPropertiesMapTest extends AbstractUniquePropertyNameTest
             Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedProperties::class))
         );
 
-        $this->assertSame(
+        self::assertSame(
             [
                 'protectedProperty0' => ClassWithMixedProperties::class,
                 'protectedProperty1' => ClassWithMixedProperties::class,
@@ -71,14 +71,14 @@ class ProtectedPropertiesMapTest extends AbstractUniquePropertyNameTest
             Properties::fromReflectionClass(new ReflectionClass(ClassWithAbstractProtectedMethod::class))
         );
 
-        $this->assertSame([], $map->getDefaultValue()->getValue());
+        self::assertSame([], $map->getDefaultValue()->getValue());
     }
 
     public function testIsStaticPrivate()
     {
         $map = $this->createProperty();
 
-        $this->assertTrue($map->isStatic());
-        $this->assertSame(ProtectedPropertiesMap::VISIBILITY_PRIVATE, $map->getVisibility());
+        self::assertTrue($map->isStatic());
+        self::assertSame(ProtectedPropertiesMap::VISIBILITY_PRIVATE, $map->getVisibility());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhostGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhostGeneratorTest.php
@@ -48,7 +48,7 @@ class LazyLoadingGhostGeneratorTest extends AbstractProxyGeneratorTest
 
         if ($reflectionClass->isInterface()) {
             // @todo interfaces *may* be proxied by deferring property localization to the constructor (no hardcoding)
-            $this->setExpectedException(InvalidProxiedClassException::class);
+            $this->expectException(InvalidProxiedClassException::class);
         }
 
         parent::testGeneratesValidCode($className);

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/GetProxyInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/GetProxyInitializerTest.php
@@ -42,12 +42,12 @@ class GetProxyInitializerTest extends PHPUnit_Framework_TestCase
         /* @var $initializer PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initializer = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $getter = new GetProxyInitializer($initializer);
 
-        $this->assertSame('getProxyInitializer', $getter->getName());
-        $this->assertCount(0, $getter->getParameters());
-        $this->assertSame('return $this->foo;', $getter->getBody());
+        self::assertSame('getProxyInitializer', $getter->getName());
+        self::assertCount(0, $getter->getParameters());
+        self::assertSame('return $this->foo;', $getter->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/InitializeProxyTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/InitializeProxyTest.php
@@ -44,14 +44,14 @@ class InitializeProxyTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $initializeProxy = new InitializeProxy($initializer, $valueHolder);
 
-        $this->assertSame('initializeProxy', $initializeProxy->getName());
-        $this->assertCount(0, $initializeProxy->getParameters());
-        $this->assertSame(
+        self::assertSame('initializeProxy', $initializeProxy->getName());
+        self::assertCount(0, $initializeProxy->getParameters());
+        self::assertSame(
             'return $this->foo && $this->foo->__invoke($this->bar, $this, \'initializeProxy\', array(), $this->foo);',
             $initializeProxy->getBody()
         );

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/IsProxyInitializedTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/IsProxyInitializedTest.php
@@ -42,13 +42,13 @@ class IsProxyInitializedTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder     = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $isProxyInitialized = new IsProxyInitialized($valueHolder);
 
-        $this->assertSame('isProxyInitialized', $isProxyInitialized->getName());
-        $this->assertCount(0, $isProxyInitialized->getParameters());
-        $this->assertSame('return null !== $this->bar;', $isProxyInitialized->getBody());
+        self::assertSame('isProxyInitialized', $isProxyInitialized->getName());
+        self::assertCount(0, $isProxyInitialized->getParameters());
+        self::assertSame('return null !== $this->bar;', $isProxyInitialized->getBody());
         self::assertStringMatchesFormat('%A : bool%A', $isProxyInitialized->generate(), 'Return type hint is boolean');
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptorTest.php
@@ -46,15 +46,15 @@ class LazyLoadingMethodInterceptorTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder      = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $reflection = new MethodReflection(BaseClass::class, 'publicByReferenceParameterMethod');
         $method     = LazyLoadingMethodInterceptor::generateMethod($reflection, $initializer, $valueHolder);
 
-        $this->assertSame('publicByReferenceParameterMethod', $method->getName());
-        $this->assertCount(2, $method->getParameters());
-        $this->assertSame(
+        self::assertSame('publicByReferenceParameterMethod', $method->getName());
+        self::assertCount(2, $method->getParameters());
+        self::assertSame(
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, 'publicByReferenceParameterMethod', "
             . "array('param' => \$param, 'byRefParam' => \$byRefParam), \$this->foo);\n\n"
             . "return \$this->bar->publicByReferenceParameterMethod(\$param, \$byRefParam);",
@@ -73,16 +73,16 @@ class LazyLoadingMethodInterceptorTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder      = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $method = LazyLoadingMethodInterceptor::generateMethod($reflectionMethod, $initializer, $valueHolder);
 
-        $this->assertSame('testBodyStructureWithoutParameters', $method->getName());
-        $this->assertCount(0, $method->getParameters());
-        $this->assertSame(
+        self::assertSame('testBodyStructureWithoutParameters', $method->getName());
+        self::assertCount(0, $method->getParameters());
+        self::assertSame(
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, "
             . "'testBodyStructureWithoutParameters', array(), \$this->foo);\n\n"
             . "return \$this->bar->testBodyStructureWithoutParameters();",

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicCloneTest.php
@@ -47,14 +47,14 @@ class MagicCloneTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicClone = new MagicClone($reflection, $initializer, $valueHolder);
 
-        $this->assertSame('__clone', $magicClone->getName());
-        $this->assertCount(0, $magicClone->getParameters());
-        $this->assertSame(
+        self::assertSame('__clone', $magicClone->getName());
+        self::assertCount(0, $magicClone->getParameters());
+        self::assertSame(
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, "
             . "'__clone', array(), \$this->foo);\n\n\$this->bar = clone \$this->bar;",
             $magicClone->getBody()

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGetTest.php
@@ -53,16 +53,16 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
-        $publicProperties->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicGet = new MagicGet($reflection, $initializer, $valueHolder, $publicProperties);
 
-        $this->assertSame('__get', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('__get', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat(
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, '__get', array('name' => \$name)"
             . ", \$this->foo);\n\n"
             . "if (isset(self::\$bar[\$name])) {\n    return \$this->bar->\$name;\n}"

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIssetTest.php
@@ -53,16 +53,16 @@ class MagicIssetTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
-        $publicProperties->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicIsset = new MagicIsset($reflection, $initializer, $valueHolder, $publicProperties);
 
-        $this->assertSame('__isset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('__isset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
+        self::assertStringMatchesFormat(
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, '__isset', array('name' => \$name)"
             . ", \$this->foo);\n\n"
             . "if (isset(self::\$bar[\$name])) {\n    return isset(\$this->bar->\$name);\n}"

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSetTest.php
@@ -53,16 +53,16 @@ class MagicSetTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
-        $publicProperties->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicSet = new MagicSet($reflection, $initializer, $valueHolder, $publicProperties);
 
-        $this->assertSame('__set', $magicSet->getName());
-        $this->assertCount(2, $magicSet->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('__set', $magicSet->getName());
+        self::assertCount(2, $magicSet->getParameters());
+        self::assertStringMatchesFormat(
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, "
             . "'__set', array('name' => \$name, 'value' => \$value), \$this->foo);\n\n"
             . "if (isset(self::\$bar[\$name])) {\n    return (\$this->bar->\$name = \$value);\n}"

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSleepTest.php
@@ -47,14 +47,14 @@ class MagicSleepTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicSleep = new MagicSleep($reflection, $initializer, $valueHolder);
 
-        $this->assertSame('__sleep', $magicSleep->getName());
-        $this->assertCount(0, $magicSleep->getParameters());
-        $this->assertSame(
+        self::assertSame('__sleep', $magicSleep->getName());
+        self::assertCount(0, $magicSleep->getParameters());
+        self::assertSame(
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, '__sleep', array(), \$this->foo);"
             . "\n\nreturn array('bar');",
             $magicSleep->getBody()

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnsetTest.php
@@ -53,16 +53,16 @@ class MagicUnsetTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
-        $publicProperties->expects($this->any())->method('isEmpty')->will($this->returnValue(false));
-        $publicProperties->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicIsset = new MagicUnset($reflection, $initializer, $valueHolder, $publicProperties);
 
-        $this->assertSame('__unset', $magicIsset->getName());
-        $this->assertCount(1, $magicIsset->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('__unset', $magicIsset->getName());
+        self::assertCount(1, $magicIsset->getParameters());
+        self::assertStringMatchesFormat(
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, '__unset', array('name' => \$name)"
             . ", \$this->foo);\n\n"
             . "if (isset(self::\$bar[\$name])) {\n    unset(\$this->bar->\$name);\n\n    return;\n}"

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/SetProxyInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/SetProxyInitializerTest.php
@@ -43,19 +43,19 @@ class SetProxyInitializerTest extends PHPUnit_Framework_TestCase
         /* @var $initializer PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $initializer = $this->getMock(PropertyGenerator::class);
 
-        $initializer->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $setter     = new SetProxyInitializer($initializer);
         $parameters = $setter->getParameters();
 
-        $this->assertSame('setProxyInitializer', $setter->getName());
-        $this->assertCount(1, $parameters);
+        self::assertSame('setProxyInitializer', $setter->getName());
+        self::assertCount(1, $parameters);
 
         /* @var $initializer ParameterGenerator */
         $initializer = array_shift($parameters);
 
-        $this->assertInstanceOf(ParameterGenerator::class, $initializer);
-        $this->assertSame('initializer', $initializer->getName());
-        $this->assertSame('$this->foo = $initializer;', $setter->getBody());
+        self::assertInstanceOf(ParameterGenerator::class, $initializer);
+        self::assertSame('initializer', $initializer->getName());
+        self::assertSame('$this->foo = $initializer;', $setter->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptorTest.php
@@ -43,9 +43,9 @@ class NullObjectMethodInterceptorTest extends PHPUnit_Framework_TestCase
         $reflection = new MethodReflection(BaseClass::class, 'publicByReferenceParameterMethod');
         $method     = NullObjectMethodInterceptor::generateMethod($reflection);
 
-        $this->assertSame('publicByReferenceParameterMethod', $method->getName());
-        $this->assertCount(2, $method->getParameters());
-        $this->assertSame("", $method->getBody());
+        self::assertSame('publicByReferenceParameterMethod', $method->getName());
+        self::assertCount(2, $method->getParameters());
+        self::assertSame("", $method->getBody());
     }
 
     /**
@@ -57,9 +57,9 @@ class NullObjectMethodInterceptorTest extends PHPUnit_Framework_TestCase
 
         $method = NullObjectMethodInterceptor::generateMethod($reflectionMethod);
 
-        $this->assertSame('testBodyStructureWithoutParameters', $method->getName());
-        $this->assertCount(0, $method->getParameters());
-        $this->assertSame("", $method->getBody());
+        self::assertSame('testBodyStructureWithoutParameters', $method->getName());
+        self::assertCount(0, $method->getParameters());
+        self::assertSame("", $method->getBody());
     }
 
     /**
@@ -71,8 +71,8 @@ class NullObjectMethodInterceptorTest extends PHPUnit_Framework_TestCase
 
         $method = NullObjectMethodInterceptor::generateMethod($reflectionMethod);
 
-        $this->assertSame('publicByReferenceMethod', $method->getName());
-        $this->assertCount(0, $method->getParameters());
-        $this->assertStringMatchesFormat("\$ref%s = null;\nreturn \$ref%s;", $method->getBody());
+        self::assertSame('publicByReferenceMethod', $method->getName());
+        self::assertCount(0, $method->getParameters());
+        self::assertStringMatchesFormat("\$ref%s = null;\nreturn \$ref%s;", $method->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObject/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObject/MethodGenerator/StaticProxyConstructorTest.php
@@ -43,9 +43,9 @@ class StaticProxyConstructorTest extends PHPUnit_Framework_TestCase
             new ReflectionClass(ClassWithMixedProperties::class)
         );
 
-        $this->assertSame('staticProxyConstructor', $constructor->getName());
-        $this->assertCount(0, $constructor->getParameters());
-        $this->assertSame(
+        self::assertSame('staticProxyConstructor', $constructor->getName());
+        self::assertCount(0, $constructor->getParameters());
+        self::assertSame(
             'static $reflection;
 
 $reflection = $reflection ?: $reflection = new \ReflectionClass(__CLASS__);
@@ -66,10 +66,10 @@ return $instance;',
             new ReflectionClass(ClassWithPrivateProperties::class)
         );
 
-        $this->assertSame('staticProxyConstructor', $constructor->getName());
-        $this->assertCount(0, $constructor->getParameters());
+        self::assertSame('staticProxyConstructor', $constructor->getName());
+        self::assertCount(0, $constructor->getParameters());
         $body = $constructor->getBody();
-        $this->assertSame(
+        self::assertSame(
             'static $reflection;
 
 $reflection = $reflection ?: $reflection = new \ReflectionClass(__CLASS__);

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
@@ -67,13 +67,13 @@ class NullObjectGeneratorTest extends AbstractProxyGeneratorTest
         $generatedReflection = new ReflectionClass($generatedClassName);
 
         if ($originalClass->isInterface()) {
-            $this->assertTrue($generatedReflection->implementsInterface($className));
+            self::assertTrue($generatedReflection->implementsInterface($className));
         }
 
-        $this->assertSame($generatedClassName, $generatedReflection->getName());
+        self::assertSame($generatedClassName, $generatedReflection->getName());
 
         foreach ($this->getExpectedImplementedInterfaces() as $interface) {
-            $this->assertTrue($generatedReflection->implementsInterface($interface));
+            self::assertTrue($generatedReflection->implementsInterface($interface));
         }
 
         $proxy = $generatedClassName::staticProxyConstructor();
@@ -81,12 +81,12 @@ class NullObjectGeneratorTest extends AbstractProxyGeneratorTest
         self::assertInstanceOf($className, $proxy);
 
         foreach (Properties::fromReflectionClass($generatedReflection)->getPublicProperties() as $property) {
-            $this->assertNull($proxy->{$property->getName()});
+            self::assertNull($proxy->{$property->getName()});
         }
 
         foreach ($generatedReflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             if (! ($method->getNumberOfParameters() || $method->isStatic())) {
-                $this->assertNull(call_user_func([$proxy, $method->getName()]));
+                self::assertNull(call_user_func([$proxy, $method->getName()]));
             }
         }
     }

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator;
 
-use PHPUnit_Framework_TestCase;
 use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;

--- a/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/AbstractUniquePropertyNameTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/AbstractUniquePropertyNameTest.php
@@ -41,8 +41,8 @@ abstract class AbstractUniquePropertyNameTest extends PHPUnit_Framework_TestCase
         $property1 = $this->createProperty();
         $property2 = $this->createProperty();
 
-        $this->assertSame($property1->getName(), $property1->getName());
-        $this->assertNotEquals($property1->getName(), $property2->getName());
+        self::assertSame($property1->getName(), $property1->getName());
+        self::assertNotEquals($property1->getName(), $property2->getName());
     }
 
     abstract protected function createProperty() : PropertyGenerator;

--- a/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/PublicPropertiesMapTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/PublicPropertiesMapTest.php
@@ -45,11 +45,11 @@ class PublicPropertiesMapTest extends PHPUnit_Framework_TestCase
             Properties::fromReflectionClass(new ReflectionClass(EmptyClass::class))
         );
 
-        $this->assertInternalType('array', $publicProperties->getDefaultValue()->getValue());
-        $this->assertEmpty($publicProperties->getDefaultValue()->getValue());
-        $this->assertTrue($publicProperties->isStatic());
-        $this->assertSame('private', $publicProperties->getVisibility());
-        $this->assertTrue($publicProperties->isEmpty());
+        self::assertInternalType('array', $publicProperties->getDefaultValue()->getValue());
+        self::assertEmpty($publicProperties->getDefaultValue()->getValue());
+        self::assertTrue($publicProperties->isStatic());
+        self::assertSame('private', $publicProperties->getVisibility());
+        self::assertTrue($publicProperties->isEmpty());
     }
 
     public function testClassWithPublicProperties()
@@ -58,11 +58,11 @@ class PublicPropertiesMapTest extends PHPUnit_Framework_TestCase
             Properties::fromReflectionClass(new ReflectionClass(ClassWithPublicProperties::class))
         );
 
-        $this->assertInternalType('array', $publicProperties->getDefaultValue()->getValue());
-        $this->assertCount(10, $publicProperties->getDefaultValue()->getValue());
-        $this->assertTrue($publicProperties->isStatic());
-        $this->assertSame('private', $publicProperties->getVisibility());
-        $this->assertFalse($publicProperties->isEmpty());
+        self::assertInternalType('array', $publicProperties->getDefaultValue()->getValue());
+        self::assertCount(10, $publicProperties->getDefaultValue()->getValue());
+        self::assertTrue($publicProperties->isStatic());
+        self::assertSame('private', $publicProperties->getVisibility());
+        self::assertFalse($publicProperties->isEmpty());
     }
 
     public function testClassWithMixedProperties()
@@ -71,6 +71,6 @@ class PublicPropertiesMapTest extends PHPUnit_Framework_TestCase
             Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedProperties::class))
         );
 
-        $this->assertCount(3, $publicProperties->getDefaultValue()->getValue());
+        self::assertCount(3, $publicProperties->getDefaultValue()->getValue());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicGetTest.php
@@ -44,13 +44,13 @@ class MagicGetTest extends PHPUnit_Framework_TestCase
         $reflection   = new ReflectionClass(EmptyClass::class);
         /* @var $adapter PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $adapter      = $this->getMock(PropertyGenerator::class);
-        $adapter->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $adapter->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $magicGet     = new MagicGet($reflection, $adapter);
 
-        $this->assertSame('__get', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('__get', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat(
             '$return = $this->foo->call(\'ProxyManagerTestAsset\\\EmptyClass\', \'__get\', array($name));'
             . "\n\nreturn \$return;",
             $magicGet->getBody()

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicIssetTest.php
@@ -44,13 +44,13 @@ class MagicIssetTest extends PHPUnit_Framework_TestCase
         $reflection   = new ReflectionClass(EmptyClass::class);
         /* @var $adapter PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $adapter      = $this->getMock(PropertyGenerator::class);
-        $adapter->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $adapter->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $magicGet     = new MagicIsset($reflection, $adapter);
 
-        $this->assertSame('__isset', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('__isset', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat(
             '$return = $this->foo->call(\'ProxyManagerTestAsset\\\EmptyClass\', \'__isset\', array($name));'
             . "\n\nreturn \$return;",
             $magicGet->getBody()

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicSetTest.php
@@ -44,13 +44,13 @@ class MagicSetTest extends PHPUnit_Framework_TestCase
         $reflection   = new ReflectionClass(EmptyClass::class);
         /* @var $adapter PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $adapter      = $this->getMock(PropertyGenerator::class);
-        $adapter->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $adapter->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $magicGet     = new MagicSet($reflection, $adapter);
 
-        $this->assertSame('__set', $magicGet->getName());
-        $this->assertCount(2, $magicGet->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('__set', $magicGet->getName());
+        self::assertCount(2, $magicGet->getParameters());
+        self::assertStringMatchesFormat(
             '$return = $this->foo->call(\'ProxyManagerTestAsset\\\EmptyClass\', \'__set\', array($name, $value));'
             . "\n\nreturn \$return;",
             $magicGet->getBody()

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicUnsetTest.php
@@ -44,13 +44,13 @@ class MagicUnsetTest extends PHPUnit_Framework_TestCase
         $reflection   = new ReflectionClass(EmptyClass::class);
         /* @var $adapter PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $adapter      = $this->getMock(PropertyGenerator::class);
-        $adapter->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $adapter->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $magicGet     = new MagicUnset($reflection, $adapter);
 
-        $this->assertSame('__unset', $magicGet->getName());
-        $this->assertCount(1, $magicGet->getParameters());
-        $this->assertStringMatchesFormat(
+        self::assertSame('__unset', $magicGet->getName());
+        self::assertCount(1, $magicGet->getParameters());
+        self::assertStringMatchesFormat(
             '$return = $this->foo->call(\'ProxyManagerTestAsset\\\EmptyClass\', \'__unset\', array($name));'
             . "\n\nreturn \$return;",
             $magicGet->getBody()

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
@@ -44,7 +44,7 @@ class RemoteObjectMethodTest extends PHPUnit_Framework_TestCase
     {
         /* @var $adapter PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $adapter = $this->getMock(PropertyGenerator::class);
-        $adapter->expects($this->any())->method('getName')->will($this->returnValue('adapter'));
+        $adapter->expects(self::any())->method('getName')->will(self::returnValue('adapter'));
 
         $reflectionMethod = new MethodReflection(
             BaseClass::class,
@@ -57,9 +57,9 @@ class RemoteObjectMethodTest extends PHPUnit_Framework_TestCase
             new ReflectionClass(PropertyGenerator::class)
         );
 
-        $this->assertSame('publicByReferenceParameterMethod', $method->getName());
-        $this->assertCount(2, $method->getParameters());
-        $this->assertSame(
+        self::assertSame('publicByReferenceParameterMethod', $method->getName());
+        self::assertCount(2, $method->getParameters());
+        self::assertSame(
             '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
             . '\'publicByReferenceParameterMethod\', array($param, $byRefParam));'
             . "\n\nreturn \$return;",
@@ -74,7 +74,7 @@ class RemoteObjectMethodTest extends PHPUnit_Framework_TestCase
     {
         /* @var $adapter PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $adapter = $this->getMock(PropertyGenerator::class);
-        $adapter->expects($this->any())->method('getName')->will($this->returnValue('adapter'));
+        $adapter->expects(self::any())->method('getName')->will(self::returnValue('adapter'));
 
         $reflectionMethod = new MethodReflection(BaseClass::class, 'publicArrayHintedMethod');
 
@@ -84,9 +84,9 @@ class RemoteObjectMethodTest extends PHPUnit_Framework_TestCase
             new ReflectionClass(PropertyGenerator::class)
         );
 
-        $this->assertSame('publicArrayHintedMethod', $method->getName());
-        $this->assertCount(1, $method->getParameters());
-        $this->assertSame(
+        self::assertSame('publicArrayHintedMethod', $method->getName());
+        self::assertCount(1, $method->getParameters());
+        self::assertSame(
             '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
             . '\'publicArrayHintedMethod\', array($param));'
             . "\n\nreturn \$return;",
@@ -101,7 +101,7 @@ class RemoteObjectMethodTest extends PHPUnit_Framework_TestCase
     {
         /* @var $adapter PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $adapter = $this->getMock(PropertyGenerator::class);
-        $adapter->expects($this->any())->method('getName')->will($this->returnValue('adapter'));
+        $adapter->expects(self::any())->method('getName')->will(self::returnValue('adapter'));
 
         $reflectionMethod = new MethodReflection(__CLASS__, 'testBodyStructureWithoutParameters');
 
@@ -111,9 +111,9 @@ class RemoteObjectMethodTest extends PHPUnit_Framework_TestCase
             new ReflectionClass(PropertyGenerator::class)
         );
 
-        $this->assertSame('testBodyStructureWithoutParameters', $method->getName());
-        $this->assertCount(0, $method->getParameters());
-        $this->assertSame(
+        self::assertSame('testBodyStructureWithoutParameters', $method->getName());
+        self::assertCount(0, $method->getParameters());
+        self::assertSame(
             '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
             . '\'testBodyStructureWithoutParameters\', array());'
             . "\n\nreturn \$return;",

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/StaticProxyConstructorTest.php
@@ -42,16 +42,16 @@ class StaticProxyConstructorTest extends PHPUnit_Framework_TestCase
         /* @var $adapter PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $adapter = $this->getMock(PropertyGenerator::class);
 
-        $adapter->expects($this->any())->method('getName')->will($this->returnValue('adapter'));
+        $adapter->expects(self::any())->method('getName')->will(self::returnValue('adapter'));
 
         $constructor = new StaticProxyConstructor(
             new ReflectionClass(ClassWithMixedProperties::class),
             $adapter
         );
 
-        $this->assertSame('staticProxyConstructor', $constructor->getName());
-        $this->assertCount(1, $constructor->getParameters());
-        $this->assertSame(
+        self::assertSame('staticProxyConstructor', $constructor->getName());
+        self::assertCount(1, $constructor->getParameters());
+        self::assertSame(
             'static $reflection;
 
 $reflection = $reflection ?: $reflection = new \ReflectionClass(__CLASS__);

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObjectGeneratorTest.php
@@ -65,17 +65,17 @@ class RemoteObjectGeneratorTest extends AbstractProxyGeneratorTest
         $generatedReflection = new ReflectionClass($generatedClassName);
 
         if ($originalClass->isInterface()) {
-            $this->assertTrue($generatedReflection->implementsInterface($className));
+            self::assertTrue($generatedReflection->implementsInterface($className));
         } else {
-            $this->assertEmpty(
+            self::assertEmpty(
                 array_diff($originalClass->getInterfaceNames(), $generatedReflection->getInterfaceNames())
             );
         }
 
-        $this->assertSame($generatedClassName, $generatedReflection->getName());
+        self::assertSame($generatedClassName, $generatedReflection->getName());
 
         foreach ($this->getExpectedImplementedInterfaces() as $interface) {
-            $this->assertTrue($generatedReflection->implementsInterface($interface));
+            self::assertTrue($generatedReflection->implementsInterface($interface));
         }
     }
 

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObjectGeneratorTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator;
 
-use PHPUnit_Framework_TestCase;
 use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PropertiesTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PropertiesTest.php
@@ -46,17 +46,17 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
         $properties       = Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedProperties::class));
         $publicProperties = $properties->getPublicProperties();
 
-        $this->assertCount(3, $publicProperties);
-        $this->assertInstanceOf(ReflectionProperty::class, $publicProperties['publicProperty0']);
-        $this->assertInstanceOf(ReflectionProperty::class, $publicProperties['publicProperty1']);
-        $this->assertInstanceOf(ReflectionProperty::class, $publicProperties['publicProperty2']);
+        self::assertCount(3, $publicProperties);
+        self::assertInstanceOf(ReflectionProperty::class, $publicProperties['publicProperty0']);
+        self::assertInstanceOf(ReflectionProperty::class, $publicProperties['publicProperty1']);
+        self::assertInstanceOf(ReflectionProperty::class, $publicProperties['publicProperty2']);
     }
 
     public function testGetPublicPropertiesSkipsAbstractMethods()
     {
         $properties = Properties::fromReflectionClass(new ReflectionClass(ClassWithAbstractPublicMethod::class));
 
-        $this->assertEmpty($properties->getPublicProperties());
+        self::assertEmpty($properties->getPublicProperties());
     }
 
     public function testGetProtectedProperties()
@@ -65,18 +65,18 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
 
         $protectedProperties = $properties->getProtectedProperties();
 
-        $this->assertCount(3, $protectedProperties);
+        self::assertCount(3, $protectedProperties);
 
-        $this->assertInstanceOf(ReflectionProperty::class, $protectedProperties["\0*\0protectedProperty0"]);
-        $this->assertInstanceOf(ReflectionProperty::class, $protectedProperties["\0*\0protectedProperty1"]);
-        $this->assertInstanceOf(ReflectionProperty::class, $protectedProperties["\0*\0protectedProperty2"]);
+        self::assertInstanceOf(ReflectionProperty::class, $protectedProperties["\0*\0protectedProperty0"]);
+        self::assertInstanceOf(ReflectionProperty::class, $protectedProperties["\0*\0protectedProperty1"]);
+        self::assertInstanceOf(ReflectionProperty::class, $protectedProperties["\0*\0protectedProperty2"]);
     }
 
     public function testGetProtectedPropertiesSkipsAbstractMethods()
     {
         $properties = Properties::fromReflectionClass(new ReflectionClass(ClassWithAbstractProtectedMethod::class));
 
-        $this->assertEmpty($properties->getProtectedProperties());
+        self::assertEmpty($properties->getProtectedProperties());
     }
 
     public function testGetPrivateProperties()
@@ -85,13 +85,13 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
 
         $privateProperties = $properties->getPrivateProperties();
 
-        $this->assertCount(3, $privateProperties);
+        self::assertCount(3, $privateProperties);
 
         $prefix = "\0" . ClassWithMixedProperties::class . "\0";
 
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'privateProperty0']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'privateProperty1']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'privateProperty2']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'privateProperty0']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'privateProperty1']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'privateProperty2']);
     }
 
     public function testGetPrivatePropertiesFromInheritance()
@@ -102,24 +102,24 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
 
         $privateProperties = $properties->getPrivateProperties();
 
-        $this->assertCount(11, $privateProperties);
+        self::assertCount(11, $privateProperties);
 
         $prefix = "\0" . ClassWithCollidingPrivateInheritedProperties::class . "\0";
 
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property0']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property0']);
 
         $prefix = "\0" . ClassWithPrivateProperties::class . "\0";
 
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property0']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property1']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property2']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property3']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property4']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property5']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property6']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property7']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property8']);
-        $this->assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property9']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property0']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property1']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property2']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property3']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property4']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property5']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property6']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property7']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property8']);
+        self::assertInstanceOf(ReflectionProperty::class, $privateProperties[$prefix . 'property9']);
     }
 
     public function testGetAccessibleMethods()
@@ -127,13 +127,13 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
         $properties           = Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedProperties::class));
         $accessibleProperties = $properties->getAccessibleProperties();
 
-        $this->assertCount(6, $accessibleProperties);
-        $this->assertInstanceOf(ReflectionProperty::class, $accessibleProperties['publicProperty0']);
-        $this->assertInstanceOf(ReflectionProperty::class, $accessibleProperties['publicProperty1']);
-        $this->assertInstanceOf(ReflectionProperty::class, $accessibleProperties['publicProperty2']);
-        $this->assertInstanceOf(ReflectionProperty::class, $accessibleProperties["\0*\0protectedProperty0"]);
-        $this->assertInstanceOf(ReflectionProperty::class, $accessibleProperties["\0*\0protectedProperty1"]);
-        $this->assertInstanceOf(ReflectionProperty::class, $accessibleProperties["\0*\0protectedProperty2"]);
+        self::assertCount(6, $accessibleProperties);
+        self::assertInstanceOf(ReflectionProperty::class, $accessibleProperties['publicProperty0']);
+        self::assertInstanceOf(ReflectionProperty::class, $accessibleProperties['publicProperty1']);
+        self::assertInstanceOf(ReflectionProperty::class, $accessibleProperties['publicProperty2']);
+        self::assertInstanceOf(ReflectionProperty::class, $accessibleProperties["\0*\0protectedProperty0"]);
+        self::assertInstanceOf(ReflectionProperty::class, $accessibleProperties["\0*\0protectedProperty1"]);
+        self::assertInstanceOf(ReflectionProperty::class, $accessibleProperties["\0*\0protectedProperty2"]);
     }
 
     public function testGetGroupedPrivateProperties()
@@ -141,15 +141,15 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
         $properties     = Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedProperties::class));
         $groupedPrivate = $properties->getGroupedPrivateProperties();
 
-        $this->assertCount(1, $groupedPrivate);
+        self::assertCount(1, $groupedPrivate);
 
         $group = $groupedPrivate[ClassWithMixedProperties::class];
 
-        $this->assertCount(3, $group);
+        self::assertCount(3, $group);
 
-        $this->assertInstanceOf(ReflectionProperty::class, $group['privateProperty0']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group['privateProperty1']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group['privateProperty2']);
+        self::assertInstanceOf(ReflectionProperty::class, $group['privateProperty0']);
+        self::assertInstanceOf(ReflectionProperty::class, $group['privateProperty1']);
+        self::assertInstanceOf(ReflectionProperty::class, $group['privateProperty2']);
     }
 
     public function testGetGroupedPrivatePropertiesWithInheritedProperties()
@@ -160,25 +160,25 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
 
         $groupedPrivate = $properties->getGroupedPrivateProperties();
 
-        $this->assertCount(2, $groupedPrivate);
+        self::assertCount(2, $groupedPrivate);
 
         $group1 = $groupedPrivate[ClassWithCollidingPrivateInheritedProperties::class];
         $group2 = $groupedPrivate[ClassWithPrivateProperties::class];
 
-        $this->assertCount(1, $group1);
-        $this->assertCount(10, $group2);
+        self::assertCount(1, $group1);
+        self::assertCount(10, $group2);
 
-        $this->assertInstanceOf(ReflectionProperty::class, $group1['property0']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property0']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property1']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property2']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property3']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property4']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property5']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property6']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property7']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property8']);
-        $this->assertInstanceOf(ReflectionProperty::class, $group2['property9']);
+        self::assertInstanceOf(ReflectionProperty::class, $group1['property0']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property0']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property1']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property2']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property3']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property4']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property5']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property6']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property7']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property8']);
+        self::assertInstanceOf(ReflectionProperty::class, $group2['property9']);
     }
 
     public function testGetInstanceProperties()
@@ -187,7 +187,7 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
             new ReflectionClass(ClassWithMixedProperties::class)
         );
 
-        $this->assertCount(9, $properties->getInstanceProperties());
+        self::assertCount(9, $properties->getInstanceProperties());
     }
 
     /**
@@ -201,10 +201,10 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
             new ReflectionClass(ClassWithMixedProperties::class)
         );
 
-        $this->assertArrayHasKey($propertyName, $properties->getInstanceProperties());
+        self::assertArrayHasKey($propertyName, $properties->getInstanceProperties());
         $filteredProperties =  $properties->filter([$propertyName]);
 
-        $this->assertArrayNotHasKey($propertyName, $filteredProperties->getInstanceProperties());
+        self::assertArrayNotHasKey($propertyName, $filteredProperties->getInstanceProperties());
     }
 
     public function testSkipOverwritedPropertyUsingInheritance()
@@ -215,10 +215,10 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
             new ReflectionClass(ClassWithCollidingPrivateInheritedProperties::class)
         );
 
-        $this->assertArrayHasKey($propertyName, $properties->getInstanceProperties());
+        self::assertArrayHasKey($propertyName, $properties->getInstanceProperties());
         $filteredProperties =  $properties->filter([$propertyName]);
 
-        $this->assertArrayNotHasKey($propertyName, $filteredProperties->getInstanceProperties());
+        self::assertArrayNotHasKey($propertyName, $filteredProperties->getInstanceProperties());
     }
 
     public function testPropertiesIsSkippedFromRelatedMethods()
@@ -227,12 +227,12 @@ class PropertiesTest extends PHPUnit_Framework_TestCase
             new ReflectionClass(ClassWithMixedProperties::class)
         );
 
-        $this->assertArrayHasKey("\0*\0protectedProperty0", $properties->getProtectedProperties());
-        $this->assertArrayHasKey("\0*\0protectedProperty0", $properties->getInstanceProperties());
+        self::assertArrayHasKey("\0*\0protectedProperty0", $properties->getProtectedProperties());
+        self::assertArrayHasKey("\0*\0protectedProperty0", $properties->getInstanceProperties());
         $filteredProperties =  $properties->filter(["\0*\0protectedProperty0"]);
 
-        $this->assertArrayNotHasKey("\0*\0protectedProperty0", $filteredProperties->getProtectedProperties());
-        $this->assertArrayNotHasKey("\0*\0protectedProperty0", $filteredProperties->getInstanceProperties());
+        self::assertArrayNotHasKey("\0*\0protectedProperty0", $filteredProperties->getProtectedProperties());
+        self::assertArrayNotHasKey("\0*\0protectedProperty0", $filteredProperties->getInstanceProperties());
     }
 
     public function propertiesToSkipFixture()

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/ProxiedMethodsFilterTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/ProxiedMethodsFilterTest.php
@@ -58,7 +58,7 @@ class ProxiedMethodsFilterTest extends PHPUnit_Framework_TestCase
         $filtered = ProxiedMethodsFilter::getProxiedMethods($reflectionClass, $excludes);
 
         foreach ($filtered as $method) {
-            $this->assertInstanceOf(ReflectionMethod::class, $method);
+            self::assertInstanceOf(ReflectionMethod::class, $method);
         }
 
         $keys = array_map(
@@ -71,7 +71,7 @@ class ProxiedMethodsFilterTest extends PHPUnit_Framework_TestCase
         sort($keys);
         sort($expectedMethods);
 
-        $this->assertSame($keys, $expectedMethods);
+        self::assertSame($keys, $expectedMethods);
     }
 
     /**
@@ -86,7 +86,7 @@ class ProxiedMethodsFilterTest extends PHPUnit_Framework_TestCase
         $filtered = ProxiedMethodsFilter::getAbstractProxiedMethods($reflectionClass, $excludes);
 
         foreach ($filtered as $method) {
-            $this->assertInstanceOf(ReflectionMethod::class, $method);
+            self::assertInstanceOf(ReflectionMethod::class, $method);
         }
 
         $keys = array_map(
@@ -99,7 +99,7 @@ class ProxiedMethodsFilterTest extends PHPUnit_Framework_TestCase
         sort($keys);
         sort($expectedMethods);
 
-        $this->assertSame($keys, $expectedMethods);
+        self::assertSame($keys, $expectedMethods);
     }
 
     /**

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator\Util;
 
+use InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
 use ProxyManager\ProxyGenerator\Util\PublicScopeSimulator;
 use Zend\Code\Generator\PropertyGenerator;
@@ -89,7 +90,7 @@ class PublicScopeSimulatorTest extends PHPUnit_Framework_TestCase
 
     public function testSetRequiresValueParameterName()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         PublicScopeSimulator::getPublicAccessSimulationCode(
             PublicScopeSimulator::OPERATION_SET,
@@ -118,7 +119,7 @@ class PublicScopeSimulatorTest extends PHPUnit_Framework_TestCase
 
     public function testSetRequiresValidOperation()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         PublicScopeSimulator::getPublicAccessSimulationCode('invalid', 'foo');
     }

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
@@ -45,7 +45,7 @@ class PublicScopeSimulatorTest extends PHPUnit_Framework_TestCase
             'bar'
         );
 
-        $this->assertStringMatchesFormat('%a{%areturn $%s->$foo;%a}%a$bar = %s;', $code);
+        self::assertStringMatchesFormat('%a{%areturn $%s->$foo;%a}%a$bar = %s;', $code);
     }
 
     public function testSimpleSet()
@@ -58,7 +58,7 @@ class PublicScopeSimulatorTest extends PHPUnit_Framework_TestCase
             'bar'
         );
 
-        $this->assertStringMatchesFormat('%a{%areturn $%s->$foo = $baz;%a}%a$bar = %s;', $code);
+        self::assertStringMatchesFormat('%a{%areturn $%s->$foo = $baz;%a}%a$bar = %s;', $code);
     }
 
     public function testSimpleIsset()
@@ -71,7 +71,7 @@ class PublicScopeSimulatorTest extends PHPUnit_Framework_TestCase
             'bar'
         );
 
-        $this->assertStringMatchesFormat('%a{%areturn isset($%s->$foo);%a}%a$bar = %s;', $code);
+        self::assertStringMatchesFormat('%a{%areturn isset($%s->$foo);%a}%a$bar = %s;', $code);
     }
 
     public function testSimpleUnset()
@@ -84,7 +84,7 @@ class PublicScopeSimulatorTest extends PHPUnit_Framework_TestCase
             'bar'
         );
 
-        $this->assertStringMatchesFormat('%a{%aunset($%s->$foo);%a}%a$bar = %s;', $code);
+        self::assertStringMatchesFormat('%a{%aunset($%s->$foo);%a}%a$bar = %s;', $code);
     }
 
     public function testSetRequiresValueParameterName()
@@ -110,7 +110,7 @@ class PublicScopeSimulatorTest extends PHPUnit_Framework_TestCase
             'bar'
         );
 
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             '%A$targetObject = $this->valueHolder;%a{%areturn $%s->$foo = $baz;%a}%a$bar = %s;',
             $code
         );
@@ -130,6 +130,6 @@ class PublicScopeSimulatorTest extends PHPUnit_Framework_TestCase
             'foo'
         );
 
-        $this->assertStringMatchesFormat('%a{%areturn $%s->$foo;%a}%areturn %s;', $code);
+        self::assertStringMatchesFormat('%a{%areturn $%s->$foo;%a}%areturn %s;', $code);
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/ConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/ConstructorTest.php
@@ -45,7 +45,7 @@ class ConstructorTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $constructor = Constructor::generateMethod(
             new ReflectionClass(
@@ -54,9 +54,9 @@ class ConstructorTest extends PHPUnit_Framework_TestCase
             $valueHolder
         );
 
-        $this->assertSame('__construct', $constructor->getName());
-        $this->assertCount(0, $constructor->getParameters());
-        $this->assertSame(
+        self::assertSame('__construct', $constructor->getName());
+        self::assertCount(0, $constructor->getParameters());
+        self::assertSame(
             'static $reflection;
 
 if (! $this->foo) {
@@ -75,16 +75,16 @@ unset($this->bar, $this->baz);
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $constructor = Constructor::generateMethod(
             new ReflectionClass(EmptyClass::class),
             $valueHolder
         );
 
-        $this->assertSame('__construct', $constructor->getName());
-        $this->assertCount(0, $constructor->getParameters());
-        $this->assertSame(
+        self::assertSame('__construct', $constructor->getName());
+        self::assertCount(0, $constructor->getParameters());
+        self::assertSame(
             'static $reflection;
 
 if (! $this->foo) {
@@ -100,12 +100,12 @@ if (! $this->foo) {
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $constructor = Constructor::generateMethod(new ReflectionClass(ClassWithMixedProperties::class), $valueHolder);
 
-        $this->assertSame('__construct', $constructor->getName());
-        $this->assertCount(0, $constructor->getParameters());
+        self::assertSame('__construct', $constructor->getName());
+        self::assertCount(0, $constructor->getParameters());
 
         $expectedCode = 'static $reflection;
 
@@ -121,7 +121,7 @@ unset($this->publicProperty0, $this->publicProperty1, $this->publicProperty2, $t
 
 }';
 
-        $this->assertSame($expectedCode, $constructor->getBody());
+        self::assertSame($expectedCode, $constructor->getBody());
     }
 
     public function testBodyStructureWithVariadicArguments()
@@ -129,15 +129,15 @@ unset($this->publicProperty0, $this->publicProperty1, $this->publicProperty2, $t
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $constructor = Constructor::generateMethod(
             new ReflectionClass(ClassWithVariadicConstructorArgument::class),
             $valueHolder
         );
 
-        $this->assertSame('__construct', $constructor->getName());
-        $this->assertCount(2, $constructor->getParameters());
+        self::assertSame('__construct', $constructor->getName());
+        self::assertCount(2, $constructor->getParameters());
 
         $expectedCode = <<<'PHP'
 static $reflection;
@@ -154,6 +154,6 @@ if (! $this->foo) {
 $this->foo->__construct($foo, ...$bar);
 PHP;
 
-        $this->assertSame($expectedCode, $constructor->getBody());
+        self::assertSame($expectedCode, $constructor->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/GetWrappedValueHolderValueTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/GetWrappedValueHolderValueTest.php
@@ -42,12 +42,12 @@ class GetWrappedValueHolderValueTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
 
         $getter = new GetWrappedValueHolderValue($valueHolder);
 
-        $this->assertSame('getWrappedValueHolderValue', $getter->getName());
-        $this->assertCount(0, $getter->getParameters());
-        $this->assertSame('return $this->foo;', $getter->getBody());
+        self::assertSame('getWrappedValueHolderValue', $getter->getName());
+        self::assertCount(0, $getter->getParameters());
+        self::assertSame('return $this->foo;', $getter->getBody());
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/MagicSleepTest.php
@@ -45,13 +45,13 @@ class MagicSleepTest extends PHPUnit_Framework_TestCase
         /* @var $valueHolder PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject */
         $valueHolder = $this->getMock(PropertyGenerator::class);
 
-        $valueHolder->expects($this->any())->method('getName')->will($this->returnValue('bar'));
+        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
 
         $magicSleep = new MagicSleep($reflection, $valueHolder);
 
-        $this->assertSame('__sleep', $magicSleep->getName());
-        $this->assertCount(0, $magicSleep->getParameters());
-        $this->assertSame(
+        self::assertSame('__sleep', $magicSleep->getName());
+        self::assertCount(0, $magicSleep->getParameters());
+        self::assertSame(
             "return array('bar');",
             $magicSleep->getBody()
         );

--- a/tests/ProxyManagerTest/Signature/ClassSignatureGeneratorTest.php
+++ b/tests/ProxyManagerTest/Signature/ClassSignatureGeneratorTest.php
@@ -62,9 +62,9 @@ class ClassSignatureGeneratorTest extends PHPUnit_Framework_TestCase
         $classGenerator = $this->getMock(ClassGenerator::class);
 
         $classGenerator
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('addPropertyFromGenerator')
-            ->with($this->callback(function (PropertyGenerator $property) : bool {
+            ->with(self::callback(function (PropertyGenerator $property) : bool {
                 return $property->getName() === 'signaturePropertyName'
                     && $property->isStatic()
                     && $property->getVisibility() === 'private'
@@ -73,17 +73,17 @@ class ClassSignatureGeneratorTest extends PHPUnit_Framework_TestCase
 
         $this
             ->signatureGenerator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('generateSignature')
             ->with(['foo' => 'bar'])
-            ->will($this->returnValue('valid-signature'));
+            ->will(self::returnValue('valid-signature'));
 
         $this
             ->signatureGenerator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('generateSignatureKey')
             ->with(['foo' => 'bar'])
-            ->will($this->returnValue('PropertyName'));
+            ->will(self::returnValue('PropertyName'));
 
         $this->classSignatureGenerator->addSignature($classGenerator, ['foo' => 'bar']);
     }

--- a/tests/ProxyManagerTest/Signature/Exception/InvalidSignatureExceptionTest.php
+++ b/tests/ProxyManagerTest/Signature/Exception/InvalidSignatureExceptionTest.php
@@ -44,12 +44,12 @@ class InvalidSignatureExceptionTest extends PHPUnit_Framework_TestCase
             'expected-signature'
         );
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'ProxyManager\Signature\Exception\InvalidSignatureException',
             $exception
         );
 
-        $this->assertSame(
+        self::assertSame(
             'Found signature "blah" for class "'
             . __CLASS__
             . '" does not correspond to expected signature "expected-signature" for 2 parameters',

--- a/tests/ProxyManagerTest/Signature/Exception/MissingSignatureExceptionTest.php
+++ b/tests/ProxyManagerTest/Signature/Exception/MissingSignatureExceptionTest.php
@@ -43,12 +43,12 @@ class MissingSignatureExceptionTest extends PHPUnit_Framework_TestCase
             'expected-signature'
         );
 
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'ProxyManager\Signature\Exception\MissingSignatureException',
             $exception
         );
 
-        $this->assertSame(
+        self::assertSame(
             'No signature found for class "'
             . __CLASS__
             . '", expected signature "expected-signature" for 2 parameters',

--- a/tests/ProxyManagerTest/Signature/SignatureCheckerTest.php
+++ b/tests/ProxyManagerTest/Signature/SignatureCheckerTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 namespace ProxyManagerTest\Signature;
 
 use PHPUnit_Framework_TestCase;
+use ProxyManager\Signature\Exception\InvalidSignatureException;
+use ProxyManager\Signature\Exception\MissingSignatureException;
 use ProxyManager\Signature\SignatureChecker;
 use ReflectionClass;
 
@@ -92,7 +94,7 @@ class SignatureCheckerTest extends PHPUnit_Framework_TestCase
             ->with(['foo' => 'bar'])
             ->will(self::returnValue('valid-signature'));
 
-        $this->setExpectedException('ProxyManager\Signature\Exception\MissingSignatureException');
+        $this->expectException(MissingSignatureException::class);
 
         $this->signatureChecker->checkSignature(new ReflectionClass($this), ['foo' => 'bar']);
     }
@@ -112,7 +114,7 @@ class SignatureCheckerTest extends PHPUnit_Framework_TestCase
             ->with(['foo' => 'bar'])
             ->will(self::returnValue('invalid-signature'));
 
-        $this->setExpectedException('ProxyManager\Signature\Exception\InvalidSignatureException');
+        $this->expectException(InvalidSignatureException::class);
 
         $this->signatureChecker->checkSignature(new ReflectionClass($this), ['foo' => 'bar']);
     }

--- a/tests/ProxyManagerTest/Signature/SignatureCheckerTest.php
+++ b/tests/ProxyManagerTest/Signature/SignatureCheckerTest.php
@@ -63,16 +63,16 @@ class SignatureCheckerTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->signatureGenerator
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('generateSignatureKey')
             ->with(['foo' => 'bar'])
-            ->will($this->returnValue('Example'));
+            ->will(self::returnValue('Example'));
         $this
             ->signatureGenerator
-            ->expects($this->atLeastOnce())
+            ->expects(self::atLeastOnce())
             ->method('generateSignature')
             ->with(['foo' => 'bar'])
-            ->will($this->returnValue('valid-signature'));
+            ->will(self::returnValue('valid-signature'));
 
         $this->signatureChecker->checkSignature(new ReflectionClass($this), ['foo' => 'bar']);
     }
@@ -81,16 +81,16 @@ class SignatureCheckerTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->signatureGenerator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('generateSignatureKey')
             ->with(['foo' => 'bar'])
-            ->will($this->returnValue('InvalidKey'));
+            ->will(self::returnValue('InvalidKey'));
         $this
             ->signatureGenerator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('generateSignature')
             ->with(['foo' => 'bar'])
-            ->will($this->returnValue('valid-signature'));
+            ->will(self::returnValue('valid-signature'));
 
         $this->setExpectedException('ProxyManager\Signature\Exception\MissingSignatureException');
 
@@ -101,16 +101,16 @@ class SignatureCheckerTest extends PHPUnit_Framework_TestCase
     {
         $this
             ->signatureGenerator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('generateSignatureKey')
             ->with(['foo' => 'bar'])
-            ->will($this->returnValue('Example'));
+            ->will(self::returnValue('Example'));
         $this
             ->signatureGenerator
-            ->expects($this->any())
+            ->expects(self::any())
             ->method('generateSignature')
             ->with(['foo' => 'bar'])
-            ->will($this->returnValue('invalid-signature'));
+            ->will(self::returnValue('invalid-signature'));
 
         $this->setExpectedException('ProxyManager\Signature\Exception\InvalidSignatureException');
 

--- a/tests/ProxyManagerTest/Signature/SignatureGeneratorTest.php
+++ b/tests/ProxyManagerTest/Signature/SignatureGeneratorTest.php
@@ -55,7 +55,7 @@ class SignatureGeneratorTest extends PHPUnit_Framework_TestCase
      */
     public function testGenerateSignature(array $parameters, string $expected)
     {
-        $this->assertSame($expected, $this->signatureGenerator->generateSignature($parameters));
+        self::assertSame($expected, $this->signatureGenerator->generateSignature($parameters));
     }
 
     /**
@@ -66,7 +66,7 @@ class SignatureGeneratorTest extends PHPUnit_Framework_TestCase
      */
     public function testGenerateSignatureKey(array $parameters, string $expected)
     {
-        $this->assertSame($expected, $this->signatureGenerator->generateSignatureKey($parameters));
+        self::assertSame($expected, $this->signatureGenerator->generateSignatureKey($parameters));
     }
 
     /**


### PR DESCRIPTION
This is mainly a cleanup PR - fixes issues in the test suite (deprecation of phpunit methods, static vs non-static method usage, unused imports)