### PR TITLE
Excluding `zendframework/zend-code` `3.0.3` from compatible dependencies (2.0.x backport)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php":                       "7.0.0 - 7.0.5 || ^7.0.7",
-        "zendframework/zend-code":   "^3.0.2",
+        "zendframework/zend-code":   "3.0.0 - 3.0.2 || ^3.0.4",
         "ocramius/package-versions": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is a backport of https://github.com/Ocramius/ProxyManager/pull/323 to the 2.0.x branches.

Refs:

 * https://github.com/Ocramius/ProxyManager/issues/321
 * https://github.com/zendframework/zend-code/pull/69
 * https://github.com/zendframework/zend-code/issues/74
 * https://github.com/zendframework/zend-code/pull/75
 * https://github.com/zendframework/zend-code/issues/80
 * https://github.com/symfony/symfony/issues/19201

As suggested by @holtkamp