### PR TITLE
Turned closure into local variable due to some serialization issues.

### DIFF
--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -40,18 +40,11 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
     protected $fileLocator;
 
     /**
-     * @var callable
-     */
-    private $emptyErrorHandler;
-
-    /**
      * @param \ProxyManager\FileLocator\FileLocatorInterface $fileLocator
      */
     public function __construct(FileLocatorInterface $fileLocator)
     {
-        $this->fileLocator       = $fileLocator;
-        $this->emptyErrorHandler = function () {
-        };
+        $this->fileLocator = $fileLocator;
     }
 
     /**
@@ -65,8 +58,10 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
             . '\\' . trim($classGenerator->getName(), '\\');
         $generatedCode = $classGenerator->generate();
         $fileName      = $this->fileLocator->getProxyFileName($className);
+        $emptyErrorHandler = function () {
+        };
 
-        set_error_handler($this->emptyErrorHandler);
+        set_error_handler($emptyErrorHandler);
 
         try {
             $this->writeFile("<?php\n\n" . $generatedCode, $fileName);


### PR DESCRIPTION
After upgrading [Disco](https://github.com/bitexpert/disco) to Proxy Manager 2, I ran into an issue with the FileWriterGeneratorStrategy class. When trying to serialize the Beanfactory Configuration class which can potentially hold a FileWriterGeneratorStrategy instance PHP will throw an error because one of the properties of FileWriterGeneratorStrategy is a closure which cannot be serialized. 

Thus I turned the closure into a local variable to work around the issue. I could not see any side-effects, but maybe there was a reason for this in the first place.