### PR TITLE
[WIP] Fix #346 - magic methods hints need to be reflected in generated child classes

### DIFF
--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGet.php
@@ -59,6 +59,7 @@ class MagicGet extends MagicMethodGenerator
 
         if (! $parent) {
             $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
+                $parent,
                 PublicScopeSimulator::OPERATION_GET,
                 'name',
                 null,

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIsset.php
@@ -59,6 +59,7 @@ class MagicIsset extends MagicMethodGenerator
 
         if (! $parent) {
             $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
+                $parent,
                 PublicScopeSimulator::OPERATION_ISSET,
                 'name',
                 null,

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSet.php
@@ -63,6 +63,7 @@ class MagicSet extends MagicMethodGenerator
 
         if (! $parent) {
             $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
+                $parent,
                 PublicScopeSimulator::OPERATION_SET,
                 'name',
                 'value',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnset.php
@@ -59,6 +59,7 @@ class MagicUnset extends MagicMethodGenerator
 
         if (! $parent) {
             $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
+                $parent,
                 PublicScopeSimulator::OPERATION_UNSET,
                 'name',
                 null,

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGet.php
@@ -64,6 +64,7 @@ class MagicGet extends MagicMethodGenerator
         $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
 
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
+            $parent,
             PublicScopeSimulator::OPERATION_GET,
             'name',
             'value',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIsset.php
@@ -63,6 +63,7 @@ class MagicIsset extends MagicMethodGenerator
         $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
 
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
+            $parent,
             PublicScopeSimulator::OPERATION_ISSET,
             'name',
             'value',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSet.php
@@ -67,6 +67,7 @@ class MagicSet extends MagicMethodGenerator
         $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
 
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
+            $parent,
             PublicScopeSimulator::OPERATION_SET,
             'name',
             'value',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnset.php
@@ -63,6 +63,7 @@ class MagicUnset extends MagicMethodGenerator
         $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
 
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
+            $parent,
             PublicScopeSimulator::OPERATION_UNSET,
             'name',
             'value',

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
@@ -135,6 +135,7 @@ PHP;
 
         if (! $override) {
             $parentAccess = PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_GET,
                 'name'
             );

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIsset.php
@@ -128,6 +128,7 @@ PHP;
 
         if (! $override) {
             $parentAccess = PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_ISSET,
                 'name'
             );

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSet.php
@@ -132,6 +132,7 @@ PHP;
 
         if (! $override) {
             $parentAccess = PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_SET,
                 'name',
                 'value'

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGet.php
@@ -54,7 +54,7 @@ class MagicGet extends MagicMethodGenerator
     ) {
         parent::__construct($originalClass, '__get', [new ParameterGenerator('name')]);
 
-        $hasParent = $originalClass->hasMethod('__get');
+        $hasParent = $originalClass->hasMethod('__get') ? $originalClass->getMethod('__get') : null;
 
         $this->setDocBlock(($hasParent ? "{@inheritDoc}\n" : '') . '@param string $name');
 
@@ -78,6 +78,7 @@ class MagicGet extends MagicMethodGenerator
             $initializer,
             $valueHolder,
             $callParent . PublicScopeSimulator::getPublicAccessSimulationCode(
+                $hasParent,
                 PublicScopeSimulator::OPERATION_GET,
                 'name',
                 null,

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIsset.php
@@ -57,8 +57,9 @@ class MagicIsset extends MagicMethodGenerator
         $initializer = $initializerProperty->getName();
         $valueHolder = $valueHolderProperty->getName();
         $callParent  = '';
+        $parent      = $originalClass->hasMethod('__isset') ? $originalClass->getMethod('__isset') : null;
 
-        $this->setDocBlock(($originalClass->hasMethod('__isset') ? "{@inheritDoc}\n" : '') . '@param string $name');
+        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
 
         if (! $publicProperties->isEmpty()) {
             $callParent = 'if (isset(self::$' . $publicProperties->getName() . "[\$name])) {\n"
@@ -67,6 +68,7 @@ class MagicIsset extends MagicMethodGenerator
         }
 
         $callParent .= PublicScopeSimulator::getPublicAccessSimulationCode(
+            $parent,
             PublicScopeSimulator::OPERATION_ISSET,
             'name',
             null,

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSet.php
@@ -58,7 +58,7 @@ class MagicSet extends MagicMethodGenerator
             [new ParameterGenerator('name'), new ParameterGenerator('value')]
         );
 
-        $hasParent   = $originalClass->hasMethod('__set');
+        $hasParent   = $originalClass->hasMethod('__set') ? $originalClass->getMethod('__set') : null;
         $initializer = $initializerProperty->getName();
         $valueHolder = $valueHolderProperty->getName();
         $callParent  = '';
@@ -74,6 +74,7 @@ class MagicSet extends MagicMethodGenerator
         $callParent .= $hasParent
             ? 'return $this->' . $valueHolder . '->__set($name, $value);'
             : PublicScopeSimulator::getPublicAccessSimulationCode(
+                $hasParent,
                 PublicScopeSimulator::OPERATION_SET,
                 'name',
                 'value',

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnset.php
@@ -54,7 +54,7 @@ class MagicUnset extends MagicMethodGenerator
     ) {
         parent::__construct($originalClass, '__unset', [new ParameterGenerator('name')]);
 
-        $hasParent   = $originalClass->hasMethod('__unset');
+        $hasParent   = $originalClass->hasMethod('__unset') ? $originalClass->getMethod('__unset') : null;
         $initializer = $initializerProperty->getName();
         $valueHolder = $valueHolderProperty->getName();
         $callParent  = '';
@@ -70,6 +70,7 @@ class MagicUnset extends MagicMethodGenerator
         $callParent .= $hasParent
             ? 'return $this->' . $valueHolder . '->__unset($name);'
             : PublicScopeSimulator::getPublicAccessSimulationCode(
+                $hasParent,
                 PublicScopeSimulator::OPERATION_UNSET,
                 'name',
                 null,

--- a/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
+++ b/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
@@ -34,6 +34,7 @@ use ProxyManagerTestAsset\ClassWithByRefMagicMethods;
 use ProxyManagerTestAsset\ClassWithCollidingPrivateInheritedProperties;
 use ProxyManagerTestAsset\ClassWithFinalMagicMethods;
 use ProxyManagerTestAsset\ClassWithFinalMethods;
+use ProxyManagerTestAsset\ClassWithHintedMagicMethods;
 use ProxyManagerTestAsset\ClassWithMagicMethods;
 use ProxyManagerTestAsset\ClassWithMethodWithByRefVariadicFunction;
 use ProxyManagerTestAsset\ClassWithMethodWithVariadicFunction;
@@ -45,6 +46,7 @@ use ProxyManagerTestAsset\ClassWithPublicProperties;
 use ProxyManagerTestAsset\ClassWithSelfHint;
 use ProxyManagerTestAsset\EmptyClass;
 use ProxyManagerTestAsset\HydratedObject;
+use ProxyManagerTestAsset\InterfaceWithHintedMagicMethods;
 use ProxyManagerTestAsset\IterableTypeHintClass;
 use ProxyManagerTestAsset\ReturnTypeHintedClass;
 use ProxyManagerTestAsset\ScalarTypeHintedClass;
@@ -119,6 +121,8 @@ class MultipleProxyGenerationTest extends PHPUnit_Framework_TestCase
         return [
             [BaseClass::class],
             [ClassWithMagicMethods::class],
+            [ClassWithHintedMagicMethods::class],
+            //[InterfaceWithHintedMagicMethods::class],
             [ClassWithFinalMethods::class],
             [ClassWithFinalMagicMethods::class],
             [ClassWithByRefMagicMethods::class],

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
@@ -72,6 +72,7 @@ PHP;
         self::assertSame(
             $expected,
             PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_GET,
                 'foo',
                 null,
@@ -106,6 +107,7 @@ PHP;
         self::assertSame(
             $expected,
             PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_SET,
                 'foo',
                 'baz',
@@ -140,6 +142,7 @@ PHP;
         self::assertSame(
             $expected,
             PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_ISSET,
                 'foo',
                 null,
@@ -174,6 +177,7 @@ PHP;
         self::assertSame(
             $expected,
             PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_UNSET,
                 'foo',
                 null,
@@ -188,6 +192,7 @@ PHP;
         $this->expectException(InvalidArgumentException::class);
 
         PublicScopeSimulator::getPublicAccessSimulationCode(
+            null,
             PublicScopeSimulator::OPERATION_SET,
             'foo',
             null,
@@ -221,6 +226,7 @@ PHP;
         self::assertSame(
             $expected,
             PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_SET,
                 'foo',
                 'baz',
@@ -234,7 +240,7 @@ PHP;
     {
         $this->expectException(InvalidArgumentException::class);
 
-        PublicScopeSimulator::getPublicAccessSimulationCode('invalid', 'foo');
+        PublicScopeSimulator::getPublicAccessSimulationCode(null, 'invalid', 'foo');
     }
 
     public function testWillReturnDirectlyWithNoReturnParam() : void
@@ -275,6 +281,7 @@ PHP;
         self::assertSame(
             $expected,
             PublicScopeSimulator::getPublicAccessSimulationCode(
+                null,
                 PublicScopeSimulator::OPERATION_GET,
                 'foo'
             )

--- a/tests/ProxyManagerTestAsset/ClassWithHintedMagicMethods.php
+++ b/tests/ProxyManagerTestAsset/ClassWithHintedMagicMethods.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset;
+
+/**
+ * Base hinted test class to play around with pre-existing magic methods
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @license MIT
+ */
+class ClassWithHintedMagicMethods
+{
+    public function __set(string $name, bool $value) : array
+    {
+        return [$name => $value];
+    }
+
+    public function __get(string $name) : string
+    {
+        return $name;
+    }
+
+    public function __isset(string $name) : bool
+    {
+        return (bool) $name;
+    }
+
+    public function __unset(string $name) : bool
+    {
+        return (bool) $name;
+    }
+
+    public function __sleep() : array
+    {
+        return [];
+    }
+
+    public function __wakeup() : void
+    {
+    }
+
+    public function __clone()
+    {
+    }
+}

--- a/tests/ProxyManagerTestAsset/InterfaceWithHintedMagicMethods.php
+++ b/tests/ProxyManagerTestAsset/InterfaceWithHintedMagicMethods.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset;
+
+/**
+ * Base hinted test interface to play around with pre-existing magic methods
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ * @license MIT
+ */
+interface InterfaceWithHintedMagicMethods
+{
+    public function __set(string $name, bool $value) : array;
+    public function __get(string $name) : string;
+    public function __isset(string $name) : bool;
+    public function __unset(string $name) : bool;
+    public function __sleep() : array;
+    public function __wakeup() : void;
+    public function __clone();
+}


### PR DESCRIPTION
This is just a patch that gets us where we want, but the introduced complexity is too much, therefore will need to find a better way to implement it, without having codegen talking to every reflection layer.