### PR TITLE
fix notice on __get error when no trace function/file is available (internal PHP functions/methods)

### DIFF
--- a/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
@@ -108,8 +108,8 @@ class PublicScopeSimulator
             . '            \'Undefined property: %s::$%s in %s on line %s\',' . "\n"
             . '            get_parent_class($this),' . "\n"
             . '            $' . $nameParameter . ',' . "\n"
-            . '            $backtrace[0][\'file\'],' . "\n"
-            . '            $backtrace[0][\'line\']' . "\n"
+            . '            $backtrace[0][\'file\'] ?? \'\',' . "\n"
+            . '            $backtrace[0][\'line\'] ?? \'\'' . "\n"
             . '        ),' . "\n"
             . '        \E_USER_NOTICE' . "\n"
             . '    );' . "\n";

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
@@ -50,8 +50,8 @@ if (! $realInstanceReflection->hasProperty($foo)) {
             'Undefined property: %s::$%s in %s on line %s',
             get_parent_class($this),
             $foo,
-            $backtrace[0]['file'],
-            $backtrace[0]['line']
+            $backtrace[0]['file'] ?? '',
+            $backtrace[0]['line'] ?? ''
         ),
         \E_USER_NOTICE
     );

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
@@ -251,8 +251,8 @@ if (! $realInstanceReflection->hasProperty($foo)) {
             'Undefined property: %s::$%s in %s on line %s',
             get_parent_class($this),
             $foo,
-            $backtrace[0]['file'],
-            $backtrace[0]['line']
+            $backtrace[0]['file'] ?? '',
+            $backtrace[0]['line'] ?? ''
         ),
         \E_USER_NOTICE
     );


### PR DESCRIPTION
If backtrace does not have file or line data error string generating caused notice