### PR TITLE
Upgrade phpunit dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "couscous/couscous":            "^1.5.2",
         "phpbench/phpbench":            "^0.12.2",
         "phpstan/phpstan":              "^0.7",
+        "nikic/php-parser":             "^3.0.4",
         "humbug/humbug":                "dev-master@DEV"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     },
     "require-dev": {
         "ext-phar":                     "*",
-        "phpunit/phpunit":              "^5.6.4",
-        "phpunit/phpunit-mock-objects": "^3.4.1",
+        "phpunit/phpunit":              "^5.7.21",
         "squizlabs/php_codesniffer":    "^2.7.0",
         "couscous/couscous":            "^1.5.2",
         "phpbench/phpbench":            "^0.12.2",

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
         "squizlabs/php_codesniffer":    "^2.7.0",
         "couscous/couscous":            "^1.5.2",
         "phpbench/phpbench":            "^0.12.2",
-        "phpstan/phpstan":              "^0.6.4",
-        "nikic/php-parser":             "^3.0.4",
+        "phpstan/phpstan":              "^0.7",
         "humbug/humbug":                "dev-master@DEV"
     },
     "suggest": {


### PR DESCRIPTION
This also fixes `master` builds, as phpunit is failing with lowest dependencies due to a subtle bug in how data-providers are reflected