### PR TITLE
Docs: Fix mixed content loading

### DIFF
--- a/doc-template/default.twig
+++ b/doc-template/default.twig
@@ -6,7 +6,7 @@
     <meta name="description" content="A proxyManager write in php" />
     <meta name="keywords" content="ProxyManager, proxy, manager, ocramius, Marco Pivetta, php" />
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600' rel='stylesheet' type='text/css'>
     <link href="{{ baseUrl }}/css/main.css" rel="stylesheet" />
     <link href="{{ baseUrl }}/css/highlight.dark.css" rel="stylesheet" />
     <script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
@@ -51,10 +51,10 @@
 <div class="component-demo" id="live-demo">
     <div class="container">
             <div class="main-wrapper" style="text-align: right">
-                <iframe src="http://ghbtns.com/github-btn.html?user=ocramius&amp;repo=ProxyManager&amp;type=fork&amp;count=true&amp;size=large"
+                <iframe src="https://ghbtns.com/github-btn.html?user=ocramius&amp;repo=ProxyManager&amp;type=fork&amp;count=true&amp;size=large"
   allowtransparency="true" frameborder="0" scrolling="0" width="310" height="40"></iframe>
 
-                <iframe src="http://ghbtns.com/github-btn.html?user=ocramius&amp;repo=ProxyManager&amp;type=watch&amp;count=true&amp;size=large"
+                <iframe src="https://ghbtns.com/github-btn.html?user=ocramius&amp;repo=ProxyManager&amp;type=watch&amp;count=true&amp;size=large"
   allowtransparency="true" frameborder="0" scrolling="0" width="200" height="40"></iframe>
 
             </div>


### PR DESCRIPTION
Fixes HTTP content being loaded from within HTTPS, which is being blocked by browsers.

(Also applies to HHVM badge, but it's not in master anymore.)