### PR TITLE
Group generated unique identifiers by name

### DIFF
--- a/src/ProxyManager/Generator/Util/UniqueIdentifierGenerator.php
+++ b/src/ProxyManager/Generator/Util/UniqueIdentifierGenerator.php
@@ -32,20 +32,24 @@ abstract class UniqueIdentifierGenerator
     const VALID_IDENTIFIER_FORMAT = '/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+$/';
     const DEFAULT_IDENTIFIER = 'g';
 
+    private static $uniqId;
+
     /**
      * Generates a valid unique identifier from the given name
      */
-    public static function getIdentifier(string $name) : string
+    public static function getIdentifier(string $name, $groupByName = false) : string
     {
-        return str_replace(
-            '.',
-            '',
-            uniqid(
-                preg_match(static::VALID_IDENTIFIER_FORMAT, $name)
-                ? $name
-                : static::DEFAULT_IDENTIFIER,
-                true
-            )
-        );
+        if (null === self::$uniqId) {
+            self::$uniqId = str_replace('.', '', uniqid('', true));
+        }
+
+        if (preg_match(static::VALID_IDENTIFIER_FORMAT, $name)) {
+            $uniqId = $groupByName ? self::$uniqId : str_replace('.', '', uniqid('', true));
+        } else {
+            $name = static::DEFAULT_IDENTIFIER;
+            $uniqId = str_replace('.', '', uniqid('', true));
+        }
+
+        return $name.$uniqId;
     }
 }

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptor/PropertyGenerator/MethodPrefixInterceptors.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptor/PropertyGenerator/MethodPrefixInterceptors.php
@@ -38,7 +38,7 @@ class MethodPrefixInterceptors extends PropertyGenerator
      */
     public function __construct()
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('methodPrefixInterceptors'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('methodPrefixInterceptors', true));
 
         $this->setDefaultValue([]);
         $this->setVisibility(self::VISIBILITY_PRIVATE);

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptor/PropertyGenerator/MethodSuffixInterceptors.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptor/PropertyGenerator/MethodSuffixInterceptors.php
@@ -38,7 +38,7 @@ class MethodSuffixInterceptors extends PropertyGenerator
      */
     public function __construct()
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('methodSuffixInterceptors'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('methodSuffixInterceptors', true));
 
         $this->setDefaultValue([]);
         $this->setVisibility(self::VISIBILITY_PRIVATE);

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
@@ -58,7 +58,7 @@ Triggers initialization logic for this ghost object
 DOCBLOCK;
 
         parent::__construct(
-            UniqueIdentifierGenerator::getIdentifier('callInitializer'),
+            UniqueIdentifierGenerator::getIdentifier('callInitializer', true),
             [
                 new ParameterGenerator('methodName'),
                 new ParameterGenerator('parameters', 'array'),

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/InitializationTracker.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/InitializationTracker.php
@@ -38,7 +38,7 @@ class InitializationTracker extends PropertyGenerator
      */
     public function __construct()
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('initializationTracker'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('initializationTracker', true));
 
         $this->setVisibility(self::VISIBILITY_PRIVATE);
         $this->setDocBlock('@var bool tracks initialization status - true while the object is initializing');

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/InitializerProperty.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/InitializerProperty.php
@@ -38,7 +38,7 @@ class InitializerProperty extends PropertyGenerator
      */
     public function __construct()
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('initializer'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('initializer', true));
 
         $this->setVisibility(self::VISIBILITY_PRIVATE);
         $this->setDocBlock('@var \\Closure|null initializer responsible for generating the wrapped object');

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/PrivatePropertiesMap.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/PrivatePropertiesMap.php
@@ -44,7 +44,7 @@ class PrivatePropertiesMap extends PropertyGenerator
     public function __construct(Properties $properties)
     {
         parent::__construct(
-            UniqueIdentifierGenerator::getIdentifier('privateProperties')
+            UniqueIdentifierGenerator::getIdentifier('privateProperties', true)
         );
 
         $this->setVisibility(self::VISIBILITY_PRIVATE);

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/ProtectedPropertiesMap.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/PropertyGenerator/ProtectedPropertiesMap.php
@@ -44,7 +44,7 @@ class ProtectedPropertiesMap extends PropertyGenerator
     public function __construct(Properties $properties)
     {
         parent::__construct(
-            UniqueIdentifierGenerator::getIdentifier('protectedProperties')
+            UniqueIdentifierGenerator::getIdentifier('protectedProperties', true)
         );
 
         $this->setVisibility(self::VISIBILITY_PRIVATE);

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/PropertyGenerator/InitializerProperty.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/PropertyGenerator/InitializerProperty.php
@@ -38,7 +38,7 @@ class InitializerProperty extends PropertyGenerator
      */
     public function __construct()
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('initializer'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('initializer', true));
 
         $this->setVisibility(self::VISIBILITY_PRIVATE);
         $this->setDocBlock('@var \\Closure|null initializer responsible for generating the wrapped object');

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/PropertyGenerator/ValueHolderProperty.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/PropertyGenerator/ValueHolderProperty.php
@@ -38,7 +38,7 @@ class ValueHolderProperty extends PropertyGenerator
      */
     public function __construct()
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('valueHolder'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('valueHolder', true));
 
         $this->setVisibility(self::VISIBILITY_PRIVATE);
         $this->setDocBlock('@var \\Closure|null initializer responsible for generating the wrapped object');

--- a/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptor.php
@@ -49,7 +49,7 @@ class NullObjectMethodInterceptor extends MethodGenerator
         }
 
         if ($originalMethod->returnsReference()) {
-            $reference = UniqueIdentifierGenerator::getIdentifier('ref');
+            $reference = UniqueIdentifierGenerator::getIdentifier('ref', true);
 
             $method->setBody("\$$reference = null;\nreturn \$$reference;");
 

--- a/src/ProxyManager/ProxyGenerator/PropertyGenerator/PublicPropertiesMap.php
+++ b/src/ProxyManager/ProxyGenerator/PropertyGenerator/PublicPropertiesMap.php
@@ -44,7 +44,7 @@ class PublicPropertiesMap extends PropertyGenerator
      */
     public function __construct(Properties $properties)
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('publicProperties'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('publicProperties', true));
 
         foreach ($properties->getPublicProperties() as $publicProperty) {
             $this->publicProperties[$publicProperty->getName()] = true;

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/PropertyGenerator/AdapterProperty.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/PropertyGenerator/AdapterProperty.php
@@ -39,7 +39,7 @@ class AdapterProperty extends PropertyGenerator
      */
     public function __construct()
     {
-        parent::__construct(UniqueIdentifierGenerator::getIdentifier('adapter'));
+        parent::__construct(UniqueIdentifierGenerator::getIdentifier('adapter', true));
 
         $this->setVisibility(self::VISIBILITY_PRIVATE);
         $this->setDocBlock('@var \\' . AdapterInterface::class . ' Remote web service adapter');

--- a/tests/ProxyManagerTest/Generator/Util/UniqueIdentifierGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/Util/UniqueIdentifierGeneratorTest.php
@@ -52,6 +52,26 @@ class UniqueIdentifierGeneratorTest extends PHPUnit_Framework_TestCase
      *
      * @param string $name
      */
+    public function testGeneratesUniqueIdentifiersByName(string $name) : void
+    {
+        if (preg_match(UniqueIdentifierGenerator::VALID_IDENTIFIER_FORMAT, $name)) {
+            self::assertSame(
+                UniqueIdentifierGenerator::getIdentifier($name, true),
+                UniqueIdentifierGenerator::getIdentifier($name, true)
+            );
+        } else {
+            self::assertNotSame(
+                UniqueIdentifierGenerator::getIdentifier($name, true),
+                UniqueIdentifierGenerator::getIdentifier($name, true)
+            );
+        }
+    }
+
+    /**
+     * @dataProvider getBaseIdentifierNames
+     *
+     * @param string $name
+     */
     public function testGeneratesValidIdentifiers(string $name) : void
     {
         self::assertRegExp(

--- a/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/AbstractUniquePropertyNameTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/AbstractUniquePropertyNameTest.php
@@ -34,7 +34,7 @@ use Zend\Code\Generator\PropertyGenerator;
 abstract class AbstractUniquePropertyNameTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * Verifies that a given property name is unique across two different instantiations of the property
+     * Verifies that a given property name is the same across two different instantiations of the property
      */
     public function testUniqueProperty() : void
     {
@@ -42,7 +42,7 @@ abstract class AbstractUniquePropertyNameTest extends PHPUnit_Framework_TestCase
         $property2 = $this->createProperty();
 
         self::assertSame($property1->getName(), $property1->getName());
-        self::assertNotEquals($property1->getName(), $property2->getName());
+        self::assertEquals($property1->getName(), $property2->getName());
     }
 
     abstract protected function createProperty() : PropertyGenerator;


### PR DESCRIPTION
This is a micro optim, that may open another one later on:
instead of generating all-time unique property names / methods, this PR allows generating per-prefix unique names. That means that e.g. the "valueHolder" property will have the same name in all generated proxies.

The benefit? Better use of the interned string cache of PHP: instead of filling it with variants of `valueHolder*`, there will be only one of them, the uniquely generated one.

The second benefit to be leveraged later is that this generates exactly same-code for magic/common methods. Which means they could be moved into generated traits, and all proxies could then "use" those traits. This would allow the PHP engine to reuse the same opcode-array for several classes, which means increased performance, by reducing the opcode-array size of the generated proxies (since even with OPcache, opcode-arrays need to be copied from shared to local memory for every request.)