### PR TITLE
Correct createProxy PHPDoc

### DIFF
--- a/src/ProxyManager/Factory/NullObjectFactory.php
+++ b/src/ProxyManager/Factory/NullObjectFactory.php
@@ -24,7 +24,7 @@ class NullObjectFactory extends AbstractBaseFactory
     private $generator;
 
     /**
-     * @param object $instanceOrClassName the object to be wrapped or interface to transform to null object
+     * @param object|string $instanceOrClassName the object to be wrapped or interface to transform to null object
      *
      * @throws InvalidSignatureException
      * @throws MissingSignatureException


### PR DESCRIPTION
There's a minor incorrect bit of PHPDoc in the NullObjectFactory. The interface states that it only takes an object, however, actually you can pass a string that is a class name and that will work too. This corrects that.