### PR TITLE
remove inheritdoc & body parsing from generated proxies

### DIFF
--- a/src/ProxyManager/Generator/MagicMethodGenerator.php
+++ b/src/ProxyManager/Generator/MagicMethodGenerator.php
@@ -24,9 +24,7 @@ class MagicMethodGenerator extends MethodGenerator
         parent::__construct(
             $name,
             $parameters,
-            static::FLAG_PUBLIC,
-            null,
-            $originalClass->hasMethod($name) ? '{@inheritDoc}' : null
+            static::FLAG_PUBLIC
         );
 
         $this->setReturnsReference(strtolower($name) === '__get');

--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace ProxyManager\Generator;
 
+use ReflectionMethod;
 use Zend\Code\Generator\MethodGenerator as ZendMethodGenerator;
+use Zend\Code\Generator\ParameterGenerator;
 use Zend\Code\Reflection\MethodReflection;
 
 /**
@@ -21,10 +23,83 @@ class MethodGenerator extends ZendMethodGenerator
     public static function fromReflection(MethodReflection $reflectionMethod) : self
     {
         /* @var $method self */
-        $method = parent::fromReflection($reflectionMethod);
+        $method = self::fromReflectionWithoutDocBlock($reflectionMethod);
 
         $method->setInterface(false);
 
         return $method;
+    }
+
+    /**
+     * @see \Zend\Code\Generator\MethodGenerator::fromReflection
+     */
+    private static function fromReflectionWithoutDocBlock(MethodReflection $reflectionMethod)
+    {
+        $method         = new static();
+        $declaringClass = $reflectionMethod->getDeclaringClass();
+
+        $method->setSourceContent($reflectionMethod->getContents(false));
+        $method->setSourceDirty(false);
+        $method->setReturnType(self::extractReturnTypeFromMethodReflection($reflectionMethod));
+
+        $method->setFinal($reflectionMethod->isFinal());
+
+        if ($reflectionMethod->isPrivate()) {
+            $method->setVisibility(self::VISIBILITY_PRIVATE);
+        } elseif ($reflectionMethod->isProtected()) {
+            $method->setVisibility(self::VISIBILITY_PROTECTED);
+        } else {
+            $method->setVisibility(self::VISIBILITY_PUBLIC);
+        }
+
+        $method->setInterface($declaringClass->isInterface());
+        $method->setStatic($reflectionMethod->isStatic());
+        $method->setReturnsReference($reflectionMethod->returnsReference());
+        $method->setName($reflectionMethod->getName());
+
+        foreach ($reflectionMethod->getParameters() as $reflectionParameter) {
+            $method->setParameter(ParameterGenerator::fromReflection($reflectionParameter));
+        }
+
+        $method->setBody(static::clearBodyIndention($reflectionMethod->getBody()));
+
+        return $method;
+    }
+
+    /**
+     * @see \Zend\Code\Generator\MethodGenerator::extractReturnTypeFromMethodReflection
+     */
+    private static function extractReturnTypeFromMethodReflection(MethodReflection $methodReflection)
+    {
+        $returnType = method_exists($methodReflection, 'getReturnType')
+            ? $methodReflection->getReturnType()
+            : null;
+
+        if (! $returnType) {
+            return null;
+        }
+
+        if (! method_exists($returnType, 'getName')) {
+            return self::expandLiteralType((string) $returnType, $methodReflection);
+        }
+
+        return ($returnType->allowsNull() ? '?' : '')
+            . self::expandLiteralType($returnType->getName(), $methodReflection);
+    }
+
+    /**
+     * @see \Zend\Code\Generator\MethodGenerator::expandLiteralType
+     */
+    private static function expandLiteralType($literalReturnType, ReflectionMethod $methodReflection)
+    {
+        if ('self' === strtolower($literalReturnType)) {
+            return $methodReflection->getDeclaringClass()->getName();
+        }
+
+        if ('parent' === strtolower($literalReturnType)) {
+            return $methodReflection->getDeclaringClass()->getParentClass()->getName();
+        }
+
+        return $literalReturnType;
     }
 }

--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -26,10 +26,7 @@ class MethodGenerator extends ZendMethodGenerator
     {
         $method = new static();
 
-        $method->setSourceContent($reflectionMethod->getContents(false));
-        $method->setSourceDirty(false);
         $method->setReturnType(self::extractReturnTypeFromMethodReflection($reflectionMethod));
-
         $method->setFinal($reflectionMethod->isFinal());
 
         if ($reflectionMethod->isPrivate()) {

--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -18,25 +18,13 @@ use Zend\Code\Reflection\MethodReflection;
 class MethodGenerator extends ZendMethodGenerator
 {
     /**
-     * {@inheritDoc}
-     */
-    public static function fromReflection(MethodReflection $reflectionMethod) : self
-    {
-        /* @var $method self */
-        $method = self::fromReflectionWithoutDocBlock($reflectionMethod);
-
-        $method->setInterface(false);
-
-        return $method;
-    }
-
-    /**
+     * Similar to fromReflection() but without copying the method body and phpdoc.
+     *
      * @see \Zend\Code\Generator\MethodGenerator::fromReflection
      */
-    private static function fromReflectionWithoutDocBlock(MethodReflection $reflectionMethod)
+    public static function fromReflectionWithoutBodyAndDocBlock(MethodReflection $reflectionMethod) : self
     {
-        $method         = new static();
-        $declaringClass = $reflectionMethod->getDeclaringClass();
+        $method = new static();
 
         $method->setSourceContent($reflectionMethod->getContents(false));
         $method->setSourceDirty(false);
@@ -52,7 +40,7 @@ class MethodGenerator extends ZendMethodGenerator
             $method->setVisibility(self::VISIBILITY_PUBLIC);
         }
 
-        $method->setInterface($declaringClass->isInterface());
+        $method->setInterface(false);
         $method->setStatic($reflectionMethod->isStatic());
         $method->setReturnsReference($reflectionMethod->returnsReference());
         $method->setName($reflectionMethod->getName());
@@ -60,8 +48,6 @@ class MethodGenerator extends ZendMethodGenerator
         foreach ($reflectionMethod->getParameters() as $reflectionParameter) {
             $method->setParameter(ParameterGenerator::fromReflection($reflectionParameter));
         }
-
-        $method->setBody(static::clearBodyIndention($reflectionMethod->getBody()));
 
         return $method;
     }

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodPrefixInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodPrefixInterceptor.php
@@ -35,7 +35,6 @@ class SetMethodPrefixInterceptor extends MethodGenerator
         $interceptor->setDefaultValue(null);
         $this->setParameter(new ParameterGenerator('methodName', 'string'));
         $this->setParameter($interceptor);
-        $this->setDocBlock('{@inheritDoc}');
         $this->setBody('$this->' . $prefixInterceptor->getName() . '[$methodName] = $prefixInterceptor;');
     }
 }

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodSuffixInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodSuffixInterceptor.php
@@ -35,7 +35,6 @@ class SetMethodSuffixInterceptor extends MethodGenerator
         $interceptor->setDefaultValue(null);
         $this->setParameter(new ParameterGenerator('methodName', 'string'));
         $this->setParameter($interceptor);
-        $this->setDocBlock('{@inheritDoc}');
         $this->setBody('$this->' . $suffixInterceptor->getName() . '[$methodName] = $suffixInterceptor;');
     }
 }

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethod.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethod.php
@@ -33,7 +33,6 @@ class InterceptedMethod extends MethodGenerator
             $forwardedParams[]   = ($parameter->isVariadic() ? '...' : '') . '$' . $parameter->getName();
         }
 
-        $method->setDocBlock('{@inheritDoc}');
         $method->setBody(InterceptorGenerator::createInterceptedMethodBody(
             '$returnValue = parent::'
             . $originalMethod->getName() . '(' . implode(', ', $forwardedParams) . ');',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethod.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethod.php
@@ -26,7 +26,7 @@ class InterceptedMethod extends MethodGenerator
         PropertyGenerator $suffixInterceptors
     ) : self {
         /* @var $method self */
-        $method          = static::fromReflection($originalMethod);
+        $method          = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $forwardedParams = [];
 
         foreach ($originalMethod->getParameters() as $parameter) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGet.php
@@ -37,8 +37,6 @@ class MagicGet extends MagicMethodGenerator
 
         $parent = GetMethodIfExists::get($originalClass, '__get');
 
-        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $callParent = '$returnValue = & parent::__get($name);';
 
         if (! $parent) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIsset.php
@@ -37,8 +37,6 @@ class MagicIsset extends MagicMethodGenerator
 
         $parent = GetMethodIfExists::get($originalClass, '__isset');
 
-        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $callParent = '$returnValue = & parent::__isset($name);';
 
         if (! $parent) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSet.php
@@ -41,8 +41,6 @@ class MagicSet extends MagicMethodGenerator
 
         $parent = GetMethodIfExists::get($originalClass, '__set');
 
-        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $callParent = '$returnValue = & parent::__set($name, $value);';
 
         if (! $parent) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnset.php
@@ -37,8 +37,6 @@ class MagicUnset extends MagicMethodGenerator
 
         $parent = GetMethodIfExists::get($originalClass, '__unset');
 
-        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $callParent = '$returnValue = & parent::__unset($name);';
 
         if (! $parent) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethod.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethod.php
@@ -27,7 +27,7 @@ class InterceptedMethod extends MethodGenerator
         PropertyGenerator $suffixInterceptors
     ) : self {
         /* @var $method self */
-        $method          = static::fromReflection($originalMethod);
+        $method          = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $forwardedParams = [];
 
         foreach ($originalMethod->getParameters() as $parameter) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethod.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethod.php
@@ -34,7 +34,6 @@ class InterceptedMethod extends MethodGenerator
             $forwardedParams[] = ($parameter->isVariadic() ? '...' : '') . '$' . $parameter->getName();
         }
 
-        $method->setDocBlock('{@inheritDoc}');
         $method->setBody(InterceptorGenerator::createInterceptedMethodBody(
             '$returnValue = $this->' . $valueHolderProperty->getName() . '->'
             . $originalMethod->getName() . '(' . implode(', ', $forwardedParams) . ');',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGet.php
@@ -45,8 +45,6 @@ class MagicGet extends MagicMethodGenerator
         $parent          = GetMethodIfExists::get($originalClass, '__get');
         $valueHolderName = $valueHolder->getName();
 
-        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
             PublicScopeSimulator::OPERATION_GET,
             'name',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIsset.php
@@ -44,8 +44,6 @@ class MagicIsset extends MagicMethodGenerator
         $parent          = GetMethodIfExists::get($originalClass, '__isset');
         $valueHolderName = $valueHolder->getName();
 
-        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
             PublicScopeSimulator::OPERATION_ISSET,
             'name',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSet.php
@@ -48,8 +48,6 @@ class MagicSet extends MagicMethodGenerator
         $parent          = GetMethodIfExists::get($originalClass, '__set');
         $valueHolderName = $valueHolder->getName();
 
-        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
             PublicScopeSimulator::OPERATION_SET,
             'name',

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnset.php
@@ -44,8 +44,6 @@ class MagicUnset extends MagicMethodGenerator
         $parent          = GetMethodIfExists::get($originalClass, '__unset');
         $valueHolderName = $valueHolder->getName();
 
-        $this->setDocBlock(($parent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
             PublicScopeSimulator::OPERATION_UNSET,
             'name',

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/GetProxyInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/GetProxyInitializer.php
@@ -26,7 +26,6 @@ class GetProxyInitializer extends MethodGenerator
     public function __construct(PropertyGenerator $initializerProperty)
     {
         parent::__construct('getProxyInitializer');
-        $this->setDocBlock('{@inheritDoc}');
         $this->setBody('return $this->' . $initializerProperty->getName() . ';');
     }
 }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/InitializeProxy.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/InitializeProxy.php
@@ -28,7 +28,6 @@ class InitializeProxy extends MethodGenerator
     public function __construct(PropertyGenerator $initializerProperty, ZendMethodGenerator $callInitializer)
     {
         parent::__construct('initializeProxy');
-        $this->setDocBlock('{@inheritDoc}');
         $this->setReturnType('bool');
 
         $this->setBody(

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/IsProxyInitialized.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/IsProxyInitialized.php
@@ -26,7 +26,6 @@ class IsProxyInitialized extends MethodGenerator
     public function __construct(PropertyGenerator $initializerProperty)
     {
         parent::__construct('isProxyInitialized');
-        $this->setDocBlock('{@inheritDoc}');
         $this->setReturnType('bool');
         $this->setBody('return ! $this->' . $initializerProperty->getName() . ';');
     }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
@@ -113,8 +113,6 @@ PHP;
 
         $override = $originalClass->hasMethod('__get');
 
-        $this->setDocBlock(($override ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $parentAccess = 'return parent::__get($name);';
 
         if (! $override) {

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIsset.php
@@ -106,8 +106,6 @@ PHP;
 
         $override = $originalClass->hasMethod('__isset');
 
-        $this->setDocBlock(($override ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $parentAccess = 'return parent::__isset($name);';
 
         if (! $override) {

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSet.php
@@ -110,8 +110,6 @@ PHP;
 
         $override = $originalClass->hasMethod('__set');
 
-        $this->setDocBlock(($override ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $parentAccess = 'return parent::__set($name, $value);';
 
         if (! $override) {

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnset.php
@@ -112,8 +112,6 @@ PHP;
 
         $override = $originalClass->hasMethod('__unset');
 
-        $this->setDocBlock(($override ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $parentAccess = 'return parent::__unset($name);';
 
         if (! $override) {

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/SetProxyInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/SetProxyInitializer.php
@@ -28,8 +28,7 @@ class SetProxyInitializer extends MethodGenerator
             'setProxyInitializer',
             [(new ParameterGenerator('initializer', 'Closure'))->setDefaultValue(null)],
             self::FLAG_PUBLIC,
-            '$this->' . $initializerProperty->getName() . ' = $initializer;',
-            '{@inheritDoc}'
+            '$this->' . $initializerProperty->getName() . ' = $initializer;'
         );
     }
 }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
@@ -137,7 +137,7 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
         return array_map(
             function (ReflectionMethod $method) : ProxyManagerMethodGenerator {
                 $generated = ProxyManagerMethodGenerator
-                    ::fromReflection(new MethodReflection($method->getDeclaringClass()->getName(), $method->getName()));
+                    ::fromReflectionWithoutBodyAndDocBlock(new MethodReflection($method->getDeclaringClass()->getName(), $method->getName()));
 
                 $generated->setAbstract(false);
 

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
@@ -136,8 +136,9 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
     {
         return array_map(
             function (ReflectionMethod $method) : ProxyManagerMethodGenerator {
-                $generated = ProxyManagerMethodGenerator
-                    ::fromReflectionWithoutBodyAndDocBlock(new MethodReflection($method->getDeclaringClass()->getName(), $method->getName()));
+                $generated = ProxyManagerMethodGenerator::fromReflectionWithoutBodyAndDocBlock(
+                    new MethodReflection($method->getDeclaringClass()->getName(), $method->getName())
+                );
 
                 $generated->setAbstract(false);
 

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/GetProxyInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/GetProxyInitializer.php
@@ -26,7 +26,6 @@ class GetProxyInitializer extends MethodGenerator
     public function __construct(PropertyGenerator $initializerProperty)
     {
         parent::__construct('getProxyInitializer');
-        $this->setDocBlock('{@inheritDoc}');
         $this->setBody('return $this->' . $initializerProperty->getName() . ';');
     }
 }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/InitializeProxy.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/InitializeProxy.php
@@ -27,7 +27,6 @@ class InitializeProxy extends MethodGenerator
     public function __construct(PropertyGenerator $initializerProperty, PropertyGenerator $valueHolderProperty)
     {
         parent::__construct('initializeProxy');
-        $this->setDocBlock('{@inheritDoc}');
         $this->setReturnType('bool');
 
         $initializer = $initializerProperty->getName();

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/IsProxyInitialized.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/IsProxyInitialized.php
@@ -26,7 +26,6 @@ class IsProxyInitialized extends MethodGenerator
     public function __construct(PropertyGenerator $valueHolderProperty)
     {
         parent::__construct('isProxyInitialized');
-        $this->setDocBlock('{@inheritDoc}');
         $this->setReturnType('bool');
         $this->setBody('return null !== $this->' . $valueHolderProperty->getName() . ';');
     }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptor.php
@@ -26,7 +26,7 @@ class LazyLoadingMethodInterceptor extends MethodGenerator
         PropertyGenerator $valueHolderProperty
     ) : self {
         /* @var $method self */
-        $method            = static::fromReflection($originalMethod);
+        $method            = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $initializerName   = $initializerProperty->getName();
         $valueHolderName   = $valueHolderProperty->getName();
         $parameters        = $originalMethod->getParameters();

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptor.php
@@ -51,7 +51,6 @@ class LazyLoadingMethodInterceptor extends MethodGenerator
                 $originalMethod
             )
         );
-        $method->setDocBlock('{@inheritDoc}');
 
         return $method;
     }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGet.php
@@ -40,8 +40,6 @@ class MagicGet extends MagicMethodGenerator
 
         $hasParent = $originalClass->hasMethod('__get');
 
-        $this->setDocBlock(($hasParent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         $initializer = $initializerProperty->getName();
         $valueHolder = $valueHolderProperty->getName();
         $callParent  = 'if (isset(self::$' . $publicProperties->getName() . "[\$name])) {\n"

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIsset.php
@@ -42,8 +42,6 @@ class MagicIsset extends MagicMethodGenerator
         $valueHolder = $valueHolderProperty->getName();
         $callParent  = '';
 
-        $this->setDocBlock(($originalClass->hasMethod('__isset') ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         if (! $publicProperties->isEmpty()) {
             $callParent = 'if (isset(self::$' . $publicProperties->getName() . "[\$name])) {\n"
                 . '    return isset($this->' . $valueHolder . '->$name);'

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSet.php
@@ -47,8 +47,6 @@ class MagicSet extends MagicMethodGenerator
         $valueHolder = $valueHolderProperty->getName();
         $callParent  = '';
 
-        $this->setDocBlock(($hasParent ? "{@inheritDoc}\n" : '') . "@param string \$name\n@param mixed \$value");
-
         if (! $publicProperties->isEmpty()) {
             $callParent = 'if (isset(self::$' . $publicProperties->getName() . "[\$name])) {\n"
                 . '    return ($this->' . $valueHolder . '->$name = $value);'

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnset.php
@@ -43,8 +43,6 @@ class MagicUnset extends MagicMethodGenerator
         $valueHolder = $valueHolderProperty->getName();
         $callParent  = '';
 
-        $this->setDocBlock(($hasParent ? "{@inheritDoc}\n" : '') . '@param string $name');
-
         if (! $publicProperties->isEmpty()) {
             $callParent = 'if (isset(self::$' . $publicProperties->getName() . "[\$name])) {\n"
                 . '    unset($this->' . $valueHolder . '->$name);' . "\n\n    return;"

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/SetProxyInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/SetProxyInitializer.php
@@ -34,7 +34,6 @@ class SetProxyInitializer extends MethodGenerator
         $initializerParameter->setType(Closure::class);
         $initializerParameter->setDefaultValue(null);
         $this->setParameter($initializerParameter);
-        $this->setDocBlock('{@inheritDoc}');
         $this->setBody('$this->' . $initializerProperty->getName() . ' = $initializer;');
     }
 }

--- a/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptor.php
@@ -24,23 +24,13 @@ class NullObjectMethodInterceptor extends MethodGenerator
     public static function generateMethod(MethodReflection $originalMethod) : self
     {
         /* @var $method self */
-        $method = static::fromReflection($originalMethod);
-
-        if ('void' === (string) $originalMethod->getReturnType()) {
-            $method->setBody('');
-
-            return $method;
-        }
+        $method = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
 
         if ($originalMethod->returnsReference()) {
             $reference = IdentifierSuffixer::getIdentifier('ref');
 
             $method->setBody("\$$reference = null;\nreturn \$$reference;");
-
-            return $method;
         }
-
-        $method->setBody('');
 
         return $method;
     }

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
@@ -32,7 +32,7 @@ class RemoteObjectMethod extends MethodGenerator
         ReflectionClass $originalClass
     ) : self {
         /* @var $method self */
-        $method        = static::fromReflection($originalMethod);
+        $method        = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $list          = array_values(array_map(
             function (ParameterGenerator $parameter) : string {
                 return '$' . $parameter->getName();

--- a/src/ProxyManager/ProxyGenerator/ValueHolder/MethodGenerator/Constructor.php
+++ b/src/ProxyManager/ProxyGenerator/ValueHolder/MethodGenerator/Constructor.php
@@ -32,7 +32,6 @@ class Constructor extends MethodGenerator
             ? self::fromReflection($originalConstructor)
             : new self('__construct');
 
-        $constructor->setDocBlock('{@inheritDoc}');
         $constructor->setBody(
             'static $reflection;' . "\n\n"
             . 'if (! $this->' . $valueHolder->getName() . ') {' . "\n"

--- a/src/ProxyManager/ProxyGenerator/ValueHolder/MethodGenerator/GetWrappedValueHolderValue.php
+++ b/src/ProxyManager/ProxyGenerator/ValueHolder/MethodGenerator/GetWrappedValueHolderValue.php
@@ -26,7 +26,6 @@ class GetWrappedValueHolderValue extends MethodGenerator
     public function __construct(PropertyGenerator $valueHolderProperty)
     {
         parent::__construct('getWrappedValueHolderValue');
-        $this->setDocBlock('{@inheritDoc}');
         $this->setBody('return $this->' . $valueHolderProperty->getName() . ';');
     }
 }

--- a/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
@@ -29,7 +29,7 @@ class MethodGeneratorTest extends TestCase
 {
     public function testGeneratedMethodsAreAllConcrete() : void
     {
-        $methodGenerator = MethodGenerator::fromReflection(new MethodReflection(
+        $methodGenerator = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
             ClassWithAbstractPublicMethod::class,
             'publicAbstractMethod'
         ));
@@ -59,25 +59,26 @@ class MethodGeneratorTest extends TestCase
      */
     public function testGenerateFromReflection() : void
     {
-        $method = MethodGenerator::fromReflection(new MethodReflection(__CLASS__, __FUNCTION__));
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(__CLASS__, __FUNCTION__));
 
         self::assertSame(__FUNCTION__, $method->getName());
         self::assertSame(MethodGenerator::VISIBILITY_PUBLIC, $method->getVisibility());
         self::assertFalse($method->isStatic());
         self::assertNull($method->getDocBlock(), 'The docblock is ignored');
+        self::assertNull($method->getBody(), 'The body is ignored');
 
-        $method = MethodGenerator::fromReflection(new MethodReflection(BaseClass::class, 'protectedMethod'));
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(BaseClass::class, 'protectedMethod'));
 
         self::assertSame(MethodGenerator::VISIBILITY_PROTECTED, $method->getVisibility());
 
-        $method = MethodGenerator::fromReflection(new MethodReflection(BaseClass::class, 'privateMethod'));
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(BaseClass::class, 'privateMethod'));
 
         self::assertSame(MethodGenerator::VISIBILITY_PRIVATE, $method->getVisibility());
     }
 
     public function testGeneratedParametersFromReflection() : void
     {
-        $method = MethodGenerator::fromReflection(new MethodReflection(
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
             BaseClass::class,
             'publicTypeHintedMethod'
         ));
@@ -101,7 +102,7 @@ class MethodGeneratorTest extends TestCase
      */
     public function testGenerateMethodWithScalarTypeHinting(string $methodName, string $type) : void
     {
-        $method = MethodGenerator::fromReflection(new MethodReflection(
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
             ScalarTypeHintedClass::class,
             $methodName
         ));
@@ -129,7 +130,7 @@ class MethodGeneratorTest extends TestCase
 
     public function testGenerateMethodWithVoidReturnTypeHinting() : void
     {
-        $method = MethodGenerator::fromReflection(new MethodReflection(
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
             VoidMethodTypeHintedInterface::class,
             'returnVoid'
         ));
@@ -146,7 +147,7 @@ class MethodGeneratorTest extends TestCase
      */
     public function testReturnTypeHintGeneration(string $methodName, string $expectedType) : void
     {
-        $method = MethodGenerator::fromReflection(new MethodReflection(
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
             ReturnTypeHintedClass::class,
             $methodName
         ));

--- a/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
@@ -59,7 +59,10 @@ class MethodGeneratorTest extends TestCase
      */
     public function testGenerateFromReflection() : void
     {
-        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(__CLASS__, __FUNCTION__));
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
+            __CLASS__,
+            __FUNCTION__
+        ));
 
         self::assertSame(__FUNCTION__, $method->getName());
         self::assertSame(MethodGenerator::VISIBILITY_PUBLIC, $method->getVisibility());
@@ -67,11 +70,17 @@ class MethodGeneratorTest extends TestCase
         self::assertNull($method->getDocBlock(), 'The docblock is ignored');
         self::assertNull($method->getBody(), 'The body is ignored');
 
-        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(BaseClass::class, 'protectedMethod'));
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
+            BaseClass::class,
+            'protectedMethod'
+        ));
 
         self::assertSame(MethodGenerator::VISIBILITY_PROTECTED, $method->getVisibility());
 
-        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(BaseClass::class, 'privateMethod'));
+        $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
+            BaseClass::class,
+            'privateMethod'
+        ));
 
         self::assertSame(MethodGenerator::VISIBILITY_PRIVATE, $method->getVisibility());
     }

--- a/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
@@ -64,7 +64,7 @@ class MethodGeneratorTest extends TestCase
         self::assertSame(__FUNCTION__, $method->getName());
         self::assertSame(MethodGenerator::VISIBILITY_PUBLIC, $method->getVisibility());
         self::assertFalse($method->isStatic());
-        self::assertSame('Verify that building from reflection works', $method->getDocBlock()->getShortDescription());
+        self::assertNull($method->getDocBlock(), 'The docblock is ignored');
 
         $method = MethodGenerator::fromReflection(new MethodReflection(BaseClass::class, 'protectedMethod'));
 

--- a/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
@@ -69,6 +69,8 @@ class MethodGeneratorTest extends TestCase
         self::assertFalse($method->isStatic());
         self::assertNull($method->getDocBlock(), 'The docblock is ignored');
         self::assertNull($method->getBody(), 'The body is ignored');
+        self::assertNull($method->getSourceContent(), 'The source content ignored');
+        self::assertTrue($method->isSourceDirty(), 'Dirty because the source cannot just be re-used when generating');
 
         $method = MethodGenerator::fromReflectionWithoutBodyAndDocBlock(new MethodReflection(
             BaseClass::class,

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptorTest.php
@@ -29,7 +29,7 @@ class NullObjectMethodInterceptorTest extends TestCase
 
         self::assertSame('publicByReferenceParameterMethod', $method->getName());
         self::assertCount(2, $method->getParameters());
-        self::assertSame('', $method->getBody());
+        self::assertNull($method->getBody());
     }
 
     /**
@@ -43,7 +43,7 @@ class NullObjectMethodInterceptorTest extends TestCase
 
         self::assertSame('testBodyStructureWithoutParameters', $method->getName());
         self::assertCount(0, $method->getParameters());
-        self::assertSame('', $method->getBody());
+        self::assertNull($method->getBody());
     }
 
     /**

--- a/tests/ProxyManagerTestAsset/AccessInterceptorValueHolderMock.php
+++ b/tests/ProxyManagerTestAsset/AccessInterceptorValueHolderMock.php
@@ -45,25 +45,16 @@ class AccessInterceptorValueHolderMock implements AccessInterceptorValueHolderIn
         return $selfInstance;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function setMethodPrefixInterceptor(string $methodName, \Closure $prefixInterceptor = null)
     {
         // no-op (on purpose)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function setMethodSuffixInterceptor(string $methodName, \Closure $suffixInterceptor = null)
     {
         // no-op (on purpose)
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getWrappedValueHolderValue()
     {
         return $this->instance;

--- a/tests/ProxyManagerTestAsset/ClassWithAbstractMagicMethods.php
+++ b/tests/ProxyManagerTestAsset/ClassWithAbstractMagicMethods.php
@@ -12,38 +12,17 @@ namespace ProxyManagerTestAsset;
  */
 abstract class ClassWithAbstractMagicMethods
 {
-    /**
-     * {@inheritDoc}
-     */
     abstract public function __set($name, $value);
 
-    /**
-     * {@inheritDoc}
-     */
     abstract public function __get($name);
 
-    /**
-     * {@inheritDoc}
-     */
     abstract public function __isset($name);
 
-    /**
-     * {@inheritDoc}
-     */
     abstract public function __unset($name);
 
-    /**
-     * {@inheritDoc}
-     */
     abstract public function __sleep();
 
-    /**
-     * {@inheritDoc}
-     */
     abstract public function __wakeup();
 
-    /**
-     * {@inheritDoc}
-     */
     abstract public function __clone();
 }

--- a/tests/ProxyManagerTestAsset/ClassWithByRefMagicMethods.php
+++ b/tests/ProxyManagerTestAsset/ClassWithByRefMagicMethods.php
@@ -12,48 +12,30 @@ namespace ProxyManagerTestAsset;
  */
 class ClassWithByRefMagicMethods
 {
-    /**
-     * {@inheritDoc}
-     */
     public function & __set($name, $value)
     {
         return [$name => $value];
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function & __get($name)
     {
         return $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function & __isset($name)
     {
         return (bool) $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function & __unset($name)
     {
         return (bool) $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function & __sleep()
     {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function & __wakeup()
     {
     }

--- a/tests/ProxyManagerTestAsset/ClassWithFinalMagicMethods.php
+++ b/tests/ProxyManagerTestAsset/ClassWithFinalMagicMethods.php
@@ -12,62 +12,38 @@ namespace ProxyManagerTestAsset;
  */
 class ClassWithFinalMagicMethods
 {
-    /**
-     * {@inheritDoc}
-     */
     final public function __construct()
     {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     final public function __set($name, $value)
     {
         return [$name => $value];
     }
 
-    /**
-     * {@inheritDoc}
-     */
     final public function __get($name)
     {
         return $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     final public function __isset($name)
     {
         return (bool) $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     final public function __unset($name)
     {
         return (bool) $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     final public function __sleep()
     {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     final public function __wakeup()
     {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     final public function __clone()
     {
     }

--- a/tests/ProxyManagerTestAsset/ClassWithMagicMethods.php
+++ b/tests/ProxyManagerTestAsset/ClassWithMagicMethods.php
@@ -12,56 +12,35 @@ namespace ProxyManagerTestAsset;
  */
 class ClassWithMagicMethods
 {
-    /**
-     * {@inheritDoc}
-     */
     public function __set($name, $value)
     {
         return [$name => $value];
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __get($name)
     {
         return $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __isset($name)
     {
         return (bool) $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __unset($name)
     {
         return (bool) $name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __sleep()
     {
         return [];
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __wakeup()
     {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __clone()
     {
     }

--- a/tests/ProxyManagerTestAsset/LazyLoadingMock.php
+++ b/tests/ProxyManagerTestAsset/LazyLoadingMock.php
@@ -35,34 +35,22 @@ class LazyLoadingMock implements VirtualProxyInterface, GhostObjectInterface
         return $instance;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function setProxyInitializer(\Closure $initializer = null)
     {
         $this->initializer = $initializer;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getProxyInitializer()
     {
         return $this->initializer;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function initializeProxy() : bool
     {
         // empty (on purpose)
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function isProxyInitialized() : bool
     {
         return true;


### PR DESCRIPTION
This removes the static `{@inheritDoc}` from the generated proxies and also fixes #229.

This reduces the memory and time overhead. A similar thing has been done in symfony for the generated container. See https://github.com/symfony/symfony/pull/18048 and https://github.com/symfony/symfony/pull/24426

`@inheritdoc` is not useful, especially in proxies that you should not explicitly be aware of anyway.
This way we neither need to generate the phpdoc from the parent definition, nor need to overwrite it with the static inheritdoc afterwards.