### PR TITLE
Updated `@var` annotation tags to the standard form

### DIFF
--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -20,7 +20,7 @@ class MethodGenerator extends ZendMethodGenerator
      */
     public static function fromReflectionWithoutBodyAndDocBlock(MethodReflection $reflectionMethod) : self
     {
-        /* @var $method self */
+        /** @var self $method */
         $method = parent::copyMethodSignature($reflectionMethod);
 
         $method->setInterface(false);

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethod.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethod.php
@@ -25,7 +25,7 @@ class InterceptedMethod extends MethodGenerator
         PropertyGenerator $prefixInterceptors,
         PropertyGenerator $suffixInterceptors
     ) : self {
-        /* @var $method self */
+        /** @var self $method */
         $method          = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $forwardedParams = [];
 

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethod.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethod.php
@@ -26,7 +26,7 @@ class InterceptedMethod extends MethodGenerator
         PropertyGenerator $prefixInterceptors,
         PropertyGenerator $suffixInterceptors
     ) : self {
-        /* @var $method self */
+        /** @var self $method */
         $method          = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $forwardedParams = [];
 

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptor.php
@@ -25,7 +25,7 @@ class LazyLoadingMethodInterceptor extends MethodGenerator
         PropertyGenerator $initializerProperty,
         PropertyGenerator $valueHolderProperty
     ) : self {
-        /* @var $method self */
+        /** @var self $method */
         $method            = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $initializerName   = $initializerProperty->getName();
         $valueHolderName   = $valueHolderProperty->getName();

--- a/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptor.php
@@ -23,7 +23,7 @@ class NullObjectMethodInterceptor extends MethodGenerator
      */
     public static function generateMethod(MethodReflection $originalMethod) : self
     {
-        /* @var $method self */
+        /** @var self $method */
         $method = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
 
         if ($originalMethod->returnsReference()) {

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
@@ -31,7 +31,7 @@ class RemoteObjectMethod extends MethodGenerator
         PropertyGenerator $adapterProperty,
         ReflectionClass $originalClass
     ) : self {
-        /* @var $method self */
+        /** @var self $method */
         $method        = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $list          = array_values(array_map(
             function (ParameterGenerator $parameter) : string {

--- a/src/ProxyManager/ProxyGenerator/ValueHolder/MethodGenerator/Constructor.php
+++ b/src/ProxyManager/ProxyGenerator/ValueHolder/MethodGenerator/Constructor.php
@@ -27,7 +27,7 @@ class Constructor extends MethodGenerator
     {
         $originalConstructor = self::getConstructor($originalClass);
 
-        /* @var $constructor self */
+        /** @var self $constructor */
         $constructor = $originalConstructor
             ? self::fromReflectionWithoutBodyAndDocBlock($originalConstructor)
             : new self('__construct');

--- a/tests/ProxyManagerTest/Factory/AccessInterceptorScopeLocalizerFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AccessInterceptorScopeLocalizerFactoryTest.php
@@ -115,7 +115,7 @@ class AccessInterceptorScopeLocalizerFactoryTest extends TestCase
         $suffixInterceptors = [function () {
             self::fail('Not supposed to be called');
         }];
-        /* @var $proxy AccessInterceptorValueHolderMock */
+        /** @var AccessInterceptorValueHolderMock $proxy */
         $proxy              = $factory->createProxy($instance, $prefixInterceptors, $suffixInterceptors);
 
         self::assertInstanceOf(AccessInterceptorValueHolderMock::class, $proxy);
@@ -192,7 +192,7 @@ class AccessInterceptorScopeLocalizerFactoryTest extends TestCase
         $suffixInterceptors = [function () {
             self::fail('Not supposed to be called');
         }];
-        /* @var $proxy AccessInterceptorValueHolderMock */
+        /** @var AccessInterceptorValueHolderMock $proxy */
         $proxy              = $factory->createProxy($instance, $prefixInterceptors, $suffixInterceptors);
 
         self::assertInstanceOf($proxyClassName, $proxy);

--- a/tests/ProxyManagerTest/Factory/AccessInterceptorValueHolderFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AccessInterceptorValueHolderFactoryTest.php
@@ -114,7 +114,7 @@ class AccessInterceptorValueHolderFactoryTest extends TestCase
         $suffixInterceptors = [function () {
             self::fail('Not supposed to be called');
         }];
-        /* @var $proxy AccessInterceptorValueHolderMock */
+        /** @var AccessInterceptorValueHolderMock $proxy */
         $proxy              = $factory->createProxy($instance, $prefixInterceptors, $suffixInterceptors);
 
         self::assertInstanceOf(AccessInterceptorValueHolderMock::class, $proxy);
@@ -191,7 +191,7 @@ class AccessInterceptorValueHolderFactoryTest extends TestCase
         $suffixInterceptors = [function () {
             self::fail('Not supposed to be called');
         }];
-        /* @var $proxy AccessInterceptorValueHolderMock */
+        /** @var AccessInterceptorValueHolderMock $proxy */
         $proxy              = $factory->createProxy($instance, $prefixInterceptors, $suffixInterceptors);
 
         self::assertInstanceOf($proxyClassName, $proxy);

--- a/tests/ProxyManagerTest/Factory/LazyLoadingGhostFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/LazyLoadingGhostFactoryTest.php
@@ -107,7 +107,7 @@ class LazyLoadingGhostFactoryTest extends TestCase
         $factory     = new LazyLoadingGhostFactory($this->config);
         $initializer = function () {
         };
-        /* @var $proxy LazyLoadingMock */
+        /** @var LazyLoadingMock $proxy */
         $proxy       = $factory->createProxy($className, $initializer);
 
         self::assertInstanceOf(LazyLoadingMock::class, $proxy);
@@ -175,7 +175,7 @@ class LazyLoadingGhostFactoryTest extends TestCase
         $factory     = new LazyLoadingGhostFactory($this->config);
         $initializer = function () {
         };
-        /* @var $proxy LazyLoadingMock */
+        /** @var LazyLoadingMock $proxy */
         $proxy       = $factory->createProxy($className, $initializer);
 
         self::assertInstanceOf($proxyClassName, $proxy);

--- a/tests/ProxyManagerTest/Factory/LazyLoadingValueHolderFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/LazyLoadingValueHolderFactoryTest.php
@@ -108,7 +108,7 @@ class LazyLoadingValueHolderFactoryTest extends TestCase
         $factory     = new LazyLoadingValueHolderFactory($this->config);
         $initializer = function () {
         };
-        /* @var $proxy LazyLoadingMock */
+        /** @var LazyLoadingMock $proxy */
         $proxy       = $factory->createProxy($className, $initializer);
 
         self::assertInstanceOf(LazyLoadingMock::class, $proxy);
@@ -176,7 +176,7 @@ class LazyLoadingValueHolderFactoryTest extends TestCase
         $factory     = new LazyLoadingValueHolderFactory($this->config);
         $initializer = function () {
         };
-        /* @var $proxy LazyLoadingMock */
+        /** @var LazyLoadingMock $proxy */
         $proxy       = $factory->createProxy($className, $initializer);
 
         self::assertInstanceOf($proxyClassName, $proxy);

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
@@ -53,13 +53,13 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
     {
         $proxyName = $this->generateProxy($className);
 
-        /* @var $proxy AccessInterceptorInterface */
+        /** @var AccessInterceptorInterface $proxy */
         $proxy     = $proxyName::staticProxyConstructor($instance);
 
         $this->assertProxySynchronized($instance, $proxy);
         self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
 
-        /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
+        /** @var callable|\PHPUnit_Framework_MockObject_MockObject $listener */
         $listener = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
         $listener
             ->expects(self::once())
@@ -108,9 +108,9 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
     ) : void {
         $proxyName = $this->generateProxy($className);
 
-        /* @var $proxy AccessInterceptorInterface */
+        /** @var AccessInterceptorInterface $proxy */
         $proxy     = $proxyName::staticProxyConstructor($instance);
-        /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
+        /* @var callable|\PHPUnit_Framework_MockObject_MockObject $listener */
         $listener  = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
         $listener
             ->expects(self::once())
@@ -158,7 +158,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
         $expectedValue
     ) : void {
         $proxyName = $this->generateProxy($className);
-        /* @var $proxy AccessInterceptorInterface */
+        /** @var AccessInterceptorInterface $proxy */
         $proxy     = unserialize(serialize($proxyName::staticProxyConstructor($instance)));
 
         self::assertSame($expectedValue, call_user_func_array([$proxy, $method], $params));
@@ -183,7 +183,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
     ) : void {
         $proxyName = $this->generateProxy($className);
 
-        /* @var $proxy AccessInterceptorInterface */
+        /** @var AccessInterceptorInterface $proxy */
         $proxy     = $proxyName::staticProxyConstructor($instance);
         $cloned    = clone $proxy;
 
@@ -268,7 +268,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
         $instance    = new ClassWithPublicArrayProperty();
         $className   = get_class($instance);
         $proxyName   = $this->generateProxy($className);
-        /* @var $proxy ClassWithPublicArrayProperty|AccessInterceptorInterface */
+        /** @var ClassWithPublicArrayProperty|AccessInterceptorInterface $proxy */
         $proxy       = $proxyName::staticProxyConstructor($instance);
 
         $proxy->arrayProperty['foo'] = 'bar';
@@ -322,7 +322,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
     {
         $instance    = new ClassWithPublicProperties();
         $proxyName   = $this->generateProxy(get_class($instance));
-        /* @var $proxy ClassWithPublicProperties|AccessInterceptorInterface */
+        /** @var ClassWithPublicProperties|AccessInterceptorInterface $proxy */
         $proxy       = $proxyName::staticProxyConstructor($instance);
         $variable    = & $proxy->property0;
 
@@ -358,7 +358,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
 
         $proxyName = $this->generateProxy(get_class($instance));
 
-        /* @var $proxy ClassWithCounterConstructor */
+        /** @var ClassWithCounterConstructor $proxy */
         $proxy = new $proxyName(15);
 
         self::assertSame(15, $proxy->amount, 'Verifying that the proxy constructor works as expected');
@@ -478,7 +478,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
         $factory       = new AccessInterceptorScopeLocalizerFactory($configuration);
         $targetObject  = new ClassWithMethodWithVariadicFunction();
 
-        /* @var $object ClassWithMethodWithVariadicFunction */
+        /** @var ClassWithMethodWithVariadicFunction $object */
         $object = $factory->createProxy(
             $targetObject,
             [
@@ -505,7 +505,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
         $factory       = new AccessInterceptorScopeLocalizerFactory($configuration);
         $targetObject  = new ClassWithMethodWithByRefVariadicFunction();
 
-        /* @var $object ClassWithMethodWithByRefVariadicFunction */
+        /** @var ClassWithMethodWithByRefVariadicFunction $object */
         $object = $factory->createProxy(
             $targetObject,
             [
@@ -531,7 +531,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
      */
     public function testWillNotForwardDynamicArguments() : void
     {
-        /* @var $object ClassWithDynamicArgumentsMethod */
+        /** @var ClassWithDynamicArgumentsMethod $object */
         $object = (new AccessInterceptorScopeLocalizerFactory())
             ->createProxy(
                 new ClassWithDynamicArgumentsMethod(),
@@ -558,7 +558,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
         $addMore   = random_int(201, 300);
         $increment = random_int(301, 400);
 
-        /* @var $object VoidCounter */
+        /** @var VoidCounter $object */
         $object = (new AccessInterceptorScopeLocalizerFactory())
             ->createProxy(
                 new VoidCounter(),

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
@@ -355,7 +355,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         $factory       = new AccessInterceptorValueHolderFactory();
         $targetObject  = new ClassWithMethodWithVariadicFunction();
 
-        /* @var $object ClassWithMethodWithVariadicFunction */
+        /** @var ClassWithMethodWithVariadicFunction $object */
         $object = $factory->createProxy(
             $targetObject,
             [
@@ -381,7 +381,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         $factory       = new AccessInterceptorValueHolderFactory();
         $targetObject  = new ClassWithMethodWithByRefVariadicFunction();
 
-        /* @var $object ClassWithMethodWithByRefVariadicFunction */
+        /** @var ClassWithMethodWithByRefVariadicFunction $object */
         $object = $factory->createProxy(
             $targetObject,
             [
@@ -412,7 +412,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
     {
         $proxyName = $this->generateProxy(ClassWithDynamicArgumentsMethod::class);
 
-        /* @var $object ClassWithDynamicArgumentsMethod */
+        /** @var ClassWithDynamicArgumentsMethod $object */
         $object = $proxyName::staticProxyConstructor(new ClassWithDynamicArgumentsMethod());
 
         self::assertSame(['a', 'b'], (new ClassWithDynamicArgumentsMethod())->dynamicArgumentsMethod('a', 'b'));
@@ -539,10 +539,10 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         string $propertyName
     ) : void {
         $proxyName = $this->generateProxy(get_class($realInstance));
-        /* @var $proxy OtherObjectAccessClass|AccessInterceptorValueHolderInterface */
+        /** @var OtherObjectAccessClass|AccessInterceptorValueHolderInterface $proxy */
         $proxy = $proxyName::staticProxyConstructor($realInstance);
 
-        /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
+        /** @var callable|\PHPUnit_Framework_MockObject_MockObject $listener */
         $listener = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
 
         $listener
@@ -557,7 +557,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
             }
         );
 
-        /* @var $accessor callable */
+        /** @var callable $accessor */
         $accessor = [$callerObject, $method];
 
         self::assertSame($expectedValue, $accessor($proxy));
@@ -582,10 +582,10 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         string $propertyName
     ) : void {
         $proxyName = $this->generateProxy(get_class($realInstance));
-        /* @var $proxy OtherObjectAccessClass|AccessInterceptorValueHolderInterface */
+        /** @var OtherObjectAccessClass|AccessInterceptorValueHolderInterface $proxy */
         $proxy = unserialize(serialize($proxyName::staticProxyConstructor($realInstance)));
 
-        /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
+        /** @var callable|\PHPUnit_Framework_MockObject_MockObject $listener */
         $listener = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
 
         $listener
@@ -626,10 +626,10 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         string $propertyName
     ) : void {
         $proxyName = $this->generateProxy(get_class($realInstance));
-        /* @var $proxy OtherObjectAccessClass|AccessInterceptorValueHolderInterface */
+        /** @var OtherObjectAccessClass|AccessInterceptorValueHolderInterface $proxy */
         $proxy = clone $proxyName::staticProxyConstructor($realInstance);
 
-        /* @var $listener callable|\PHPUnit_Framework_MockObject_MockObject */
+        /** @var callable|\PHPUnit_Framework_MockObject_MockObject $listener */
         $listener = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
 
         $listener
@@ -644,7 +644,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
             }
         );
 
-        /* @var $accessor callable */
+        /** @var callable $accessor */
         $accessor = [$callerObject, $method];
 
         self::assertSame($expectedValue, $accessor($proxy));
@@ -699,7 +699,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
 
         $proxyName = $this->generateProxy(VoidCounter::class);
 
-        /* @var $object VoidCounter */
+        /** @var VoidCounter $object */
         $object = $proxyName::staticProxyConstructor(
             new VoidCounter(),
             [

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethodTest.php
@@ -24,12 +24,12 @@ use Zend\Code\Reflection\MethodReflection;
 class InterceptedMethodTest extends TestCase
 {
     /**
-     * @var $prefixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject
+     * @var PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject
      */
     private $prefixInterceptors;
 
     /**
-     * @var $suffixInterceptors PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject
+     * @var PropertyGenerator|\PHPUnit_Framework_MockObject_MockObject
      */
     private $suffixInterceptors;
 


### PR DESCRIPTION
Something to make upgrading to PHPStan 0.9 easier 😊 One of the BC breaks is that the only `@var` form supported is `@var Type $variableName` and it must be inside a DOC COMMENT token (`/** ... */`).