### PR TITLE
FileWriterGenerator temp name fix

### DIFF
--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -74,7 +74,8 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
      */
     private function writeFile(string $source, string $location) : void
     {
-        $tmpFileName = tempnam($location, 'temporaryProxyManagerFile');
+        $tempDir = dirname($location);
+        $tmpFileName = tempnam($tempDir, 'temporaryProxyManagerFile');
 
         file_put_contents($tmpFileName, $source);
 


### PR DESCRIPTION
tempname will not work on location that includes proxy php class file name, as passed  in location. This is generated in generate() as from the $this->fileLocator->getProxyFileName($className). In reality we need the dirname base path of the desired location to pass into tempname.