### PR TITLE
Fix proxying an interface and using a dynamic property on the proxy

### DIFF
--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGet.php
@@ -63,7 +63,8 @@ class MagicGet extends MagicMethodGenerator
                 'name',
                 null,
                 null,
-                'returnValue'
+                'returnValue',
+                $originalClass->isInterface() ? $originalClass->getName() : null
             );
         }
 

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIsset.php
@@ -63,7 +63,8 @@ class MagicIsset extends MagicMethodGenerator
                 'name',
                 null,
                 null,
-                'returnValue'
+                'returnValue',
+                $originalClass->isInterface() ? $originalClass->getName() : null
             );
         }
 

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSet.php
@@ -67,7 +67,8 @@ class MagicSet extends MagicMethodGenerator
                 'name',
                 'value',
                 null,
-                'returnValue'
+                'returnValue',
+                $originalClass->isInterface() ? $originalClass->getName() : null
             );
         }
 

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnset.php
@@ -63,7 +63,8 @@ class MagicUnset extends MagicMethodGenerator
                 'name',
                 null,
                 null,
-                'returnValue'
+                'returnValue',
+                $originalClass->isInterface() ? $originalClass->getName() : null
             );
         }
 

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGet.php
@@ -68,7 +68,8 @@ class MagicGet extends MagicMethodGenerator
             'name',
             'value',
             $valueHolder,
-            'returnValue'
+            'returnValue',
+            $originalClass->isInterface() ? $originalClass->getName() : null
         );
 
         if (! $publicProperties->isEmpty()) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIsset.php
@@ -67,7 +67,8 @@ class MagicIsset extends MagicMethodGenerator
             'name',
             'value',
             $valueHolder,
-            'returnValue'
+            'returnValue',
+            $originalClass->isInterface() ? $originalClass->getName() : null
         );
 
         if (! $publicProperties->isEmpty()) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSet.php
@@ -71,7 +71,8 @@ class MagicSet extends MagicMethodGenerator
             'name',
             'value',
             $valueHolder,
-            'returnValue'
+            'returnValue',
+            $originalClass->isInterface() ? $originalClass->getName() : null
         );
 
         if (! $publicProperties->isEmpty()) {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnset.php
@@ -67,7 +67,8 @@ class MagicUnset extends MagicMethodGenerator
             'name',
             'value',
             $valueHolder,
-            'returnValue'
+            'returnValue',
+            $originalClass->isInterface() ? $originalClass->getName() : null
         );
 
         if (! $publicProperties->isEmpty()) {

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGet.php
@@ -81,7 +81,9 @@ class MagicGet extends MagicMethodGenerator
                 PublicScopeSimulator::OPERATION_GET,
                 'name',
                 null,
-                $valueHolderProperty
+                $valueHolderProperty,
+                null,
+                $originalClass->isInterface() ? $originalClass->getName() : null
             )
         );
     }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIsset.php
@@ -70,7 +70,9 @@ class MagicIsset extends MagicMethodGenerator
             PublicScopeSimulator::OPERATION_ISSET,
             'name',
             null,
-            $valueHolderProperty
+            $valueHolderProperty,
+            null,
+            $originalClass->isInterface() ? $originalClass->getName() : null
         );
 
         $this->setBody(

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSet.php
@@ -77,7 +77,9 @@ class MagicSet extends MagicMethodGenerator
                 PublicScopeSimulator::OPERATION_SET,
                 'name',
                 'value',
-                $valueHolderProperty
+                $valueHolderProperty,
+                null,
+                $originalClass->isInterface() ? $originalClass->getName() : null
             );
 
         $this->setBody(

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnset.php
@@ -73,7 +73,9 @@ class MagicUnset extends MagicMethodGenerator
                 PublicScopeSimulator::OPERATION_UNSET,
                 'name',
                 null,
-                $valueHolderProperty
+                $valueHolderProperty,
+                null,
+                $originalClass->isInterface() ? $originalClass->getName() : null
             );
 
         $this->setBody(

--- a/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
@@ -49,6 +49,7 @@ class PublicScopeSimulator
      *                                              to read the property. `$this` if none provided
      * @param string|null       $returnPropertyName name of the property to which we want to assign the result of
      *                                              the operation. Return directly if none provided
+     * @param string|null       $interfaceName      name of the proxified interface if any
      *
      * @return string
      *
@@ -57,9 +58,10 @@ class PublicScopeSimulator
     public static function getPublicAccessSimulationCode(
         string $operationType,
         string $nameParameter,
-        $valueParameter = null,
+        string $valueParameter = null,
         PropertyGenerator $valueHolder = null,
-        $returnPropertyName = null
+        string $returnPropertyName = null,
+        string $interfaceName = null
     ) : string {
         $byRef  = self::getByRefReturnValue($operationType);
         $value  = static::OPERATION_SET === $operationType ? ', $value' : '';
@@ -67,6 +69,12 @@ class PublicScopeSimulator
 
         if ($valueHolder) {
             $target = '$this->' . $valueHolder->getName();
+        }
+
+        if (null !== $interfaceName) {
+            return '$targetObject = ' . $target . ';' . "\n\n"
+                . self::getUndefinedPropertyNotice($operationType, $nameParameter, $interfaceName)
+                . self::getOperation($operationType, $nameParameter, $valueParameter);
         }
 
         return '$realInstanceReflection = new \\ReflectionClass(get_parent_class($this));' . "\n\n"
@@ -96,23 +104,29 @@ class PublicScopeSimulator
      *
      * @return string
      */
-    private static function getUndefinedPropertyNotice(string $operationType, string $nameParameter) : string
+    private static function getUndefinedPropertyNotice(string $operationType, string $nameParameter, string $interfaceName = null) : string
     {
         if (static::OPERATION_GET !== $operationType) {
             return '';
         }
 
-        return '    $backtrace = debug_backtrace(false);' . "\n"
+        $code = '    $backtrace = debug_backtrace(false, 1);' . "\n"
             . '    trigger_error(' . "\n"
             . '        sprintf(' . "\n"
             . '            \'Undefined property: %s::$%s in %s on line %s\',' . "\n"
-            . '            get_parent_class($this),' . "\n"
+            . '            ' . (null !== $interfaceName ? var_export($interfaceName, true) : 'get_parent_class($this)') . ',' . "\n"
             . '            $' . $nameParameter . ',' . "\n"
             . '            $backtrace[0][\'file\'],' . "\n"
             . '            $backtrace[0][\'line\']' . "\n"
             . '        ),' . "\n"
             . '        \E_USER_NOTICE' . "\n"
             . '    );' . "\n";
+
+        if (null !== $interfaceName) {
+            $code = str_replace("\n    ", "\n", substr($code, 4));
+        }
+
+        return $code;
     }
 
     /**
@@ -183,7 +197,7 @@ class PublicScopeSimulator
      */
     private static function getScopeReBind() : string
     {
-        return '$backtrace = debug_backtrace(true);' . "\n"
+        return '$backtrace = debug_backtrace(true, 2);' . "\n"
             . '$scopeObject = isset($backtrace[1][\'object\'])'
             . ' ? $backtrace[1][\'object\'] : new \ProxyManager\Stub\EmptyClassStub();' . "\n"
             . '$accessor = $accessor->bindTo($scopeObject, get_class($scopeObject));' . "\n";

--- a/tests/language-feature-scripts/lazy-loading-value-holder-interface-proxy.phpt
+++ b/tests/language-feature-scripts/lazy-loading-value-holder-interface-proxy.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Verifies that lazy loading value holder factory can generate proxy for interfaces.
+?>
+--FILE--
+<?php
+
+require_once __DIR__ . '/init.php';
+
+interface MyInterface
+{
+    public function do();
+}
+
+class MyClass implements MyInterface
+{
+    public function do()
+    {
+        echo 'Hello';
+    }
+}
+
+$factory = new \ProxyManager\Factory\LazyLoadingValueHolderFactory($configuration);
+
+$proxy = $factory
+    ->createProxy(MyInterface::class, function (& $wrapped, $proxy, $method, array $parameters, & $initializer) {
+        $initializer = null;
+        $wrapped     = new MyClass();
+    });
+
+$proxy->do();
+$proxy->someDynamicProperty = ' World';
+echo @$proxy->someDynamicProperty;
+
+?>
+--EXPECT--
+Hello World


### PR DESCRIPTION
Submitting on branch 2.1 because that's the lowest one compatible with PHP 7.1, thus Symfony 4.

When an interface is proxied, should the dynamic property be forwarded to the wrapped value? ~I would prefer not actually, so it'd stay only on the proxy.~