### PR TITLE
FileWriterGeneratorStrategy: Set file permissions on the generated proxy

### DIFF
--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -77,6 +77,7 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
         $tmpFileName = tempnam($location, 'temporaryProxyManagerFile');
 
         file_put_contents($tmpFileName, $source);
+        @chmod($tmpFileName, 0666 & ~umask());
 
         if (! rename($tmpFileName, $location)) {
             unlink($tmpFileName);

--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -77,7 +77,7 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
         $tmpFileName = tempnam($location, 'temporaryProxyManagerFile');
 
         file_put_contents($tmpFileName, $source);
-        @chmod($tmpFileName, 0666 & ~umask());
+        chmod($tmpFileName, 0666 & ~umask());
 
         if (! rename($tmpFileName, $location)) {
             unlink($tmpFileName);

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -45,6 +45,13 @@ class FileWriterGeneratorStrategyTest extends TestCase
         self::assertGreaterThan(0, strpos($body, $className));
         self::assertFalse(class_exists($fqcn, false));
         self::assertFileExists($tmpFile);
+        self::assertFileIsReadable($tmpFile);
+
+        // a user not on php.net recommended calling this as we have just called chmod on a file.
+        clearstatcache();
+
+        $perm = 0666 & ~umask();
+        self::assertTrue($perm === (fileperms($tmpFile) & 0644), 'File permission was not correct: ' . decoct($perm));
 
         /* @noinspection PhpIncludeInspection */
         require $tmpFile;

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -47,7 +47,7 @@ class FileWriterGeneratorStrategyTest extends TestCase
         self::assertFileExists($tmpFile);
         self::assertFileIsReadable($tmpFile);
 
-        // a user not on php.net recommended calling this as we have just called chmod on a file.
+        // a user note on php.net recommended calling this as we have just called chmod on a file.
         clearstatcache();
 
         // Calculate the permission that should have been set.

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -51,6 +51,7 @@ class FileWriterGeneratorStrategyTest extends TestCase
         clearstatcache();
 
         // Calculate the permission that should have been set.
+        // The operators below are bit-wise "AND" (&) and "NOT" (~), read more at: http://php.net/manual/en/language.operators.bitwise.php
         $perm = 0666 & ~umask();
 
         self::assertSame($perm, fileperms($tmpFile) & 0644, 'File permission was not correct: ' . decoct($perm));

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -50,8 +50,10 @@ class FileWriterGeneratorStrategyTest extends TestCase
         // a user not on php.net recommended calling this as we have just called chmod on a file.
         clearstatcache();
 
+        // Calculate the permission that should have been set.
         $perm = 0666 & ~umask();
-        self::assertTrue($perm === (fileperms($tmpFile) & 0644), 'File permission was not correct: ' . decoct($perm));
+
+        self::assertSame($perm, fileperms($tmpFile) & 0644, 'File permission was not correct: ' . decoct($perm));
 
         /* @noinspection PhpIncludeInspection */
         require $tmpFile;


### PR DESCRIPTION
The exact call for chmod is inspired by twig: https://github.com/twigphp/Twig/blob/2.x/lib/Twig/Cache/Filesystem.php#L64