### PR TITLE
Crashing test assets for magic methods with types/void

### DIFF
--- a/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
+++ b/tests/ProxyManagerTest/Functional/MultipleProxyGenerationTest.php
@@ -27,6 +27,8 @@ use ProxyManagerTestAsset\ClassWithPrivateProperties;
 use ProxyManagerTestAsset\ClassWithProtectedProperties;
 use ProxyManagerTestAsset\ClassWithPublicProperties;
 use ProxyManagerTestAsset\ClassWithSelfHint;
+use ProxyManagerTestAsset\ClassWithTypedMagicMethods;
+use ProxyManagerTestAsset\ClassWithVoidReturningMethods;
 use ProxyManagerTestAsset\EmptyClass;
 use ProxyManagerTestAsset\HydratedObject;
 use ProxyManagerTestAsset\IterableTypeHintClass;
@@ -115,6 +117,8 @@ class MultipleProxyGenerationTest extends TestCase
             [ClassWithCollidingPrivateInheritedProperties::class],
             [ClassWithMethodWithVariadicFunction::class],
             [ClassWithMethodWithByRefVariadicFunction::class],
+            [ClassWithVoidReturningMethods::class],
+            [ClassWithTypedMagicMethods::class],
             [ScalarTypeHintedClass::class],
             [IterableTypeHintClass::class],
             [ObjectTypeHintClass::class],

--- a/tests/ProxyManagerTestAsset/ClassWithTypedMagicMethods.php
+++ b/tests/ProxyManagerTestAsset/ClassWithTypedMagicMethods.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset;
+
+/**
+ * Test class used to verify that proxy-manager respects typed magic methods
+ */
+class ClassWithTypedMagicMethods
+{
+    public function __set(int $name, bool $value) : void
+    {
+    }
+
+    public function __get(int $name) : bool
+    {
+        return false;
+    }
+
+    public function __isset(int $name) : object
+    {
+        return $this;
+    }
+
+    public function __unset(int $name) : object
+    {
+        return $this;
+    }
+
+    public function __sleep() : int
+    {
+        return 123;
+    }
+
+    public function __wakeup() : int
+    {
+    }
+}

--- a/tests/ProxyManagerTestAsset/ClassWithVoidReturningMethods.php
+++ b/tests/ProxyManagerTestAsset/ClassWithVoidReturningMethods.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset;
+
+/**
+ * Test class used to verify that proxy-manager respects void return types on magic methods
+ */
+class ClassWithVoidReturningMethods
+{
+    public function __set($name, $value) : void
+    {
+    }
+
+    public function __get($name) : void
+    {
+    }
+
+    public function __isset($name) : void
+    {
+    }
+
+    public function __unset($name) : void
+    {
+    }
+
+    public function __sleep() : void
+    {
+    }
+
+    public function __wakeup() : void
+    {
+    }
+}


### PR DESCRIPTION
Right now just failing (crashing) test assets.

Related to #350.