### PR TITLE
#421 ensure that even less restrictive `umask()` usages are covered by the file permission test assertions

### DIFF
--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -62,7 +62,7 @@ class FileWriterGeneratorStrategyTest extends TestCase
         // The operators below are bit-wise "AND" (&) and "NOT" (~), read more at: http://php.net/manual/en/language.operators.bitwise.php
         $perm = 0666 & ~umask();
 
-        self::assertSame($perm, fileperms($tmpFile) & 0644, 'File permission was not correct: ' . decoct($perm));
+        self::assertSame($perm, fileperms($tmpFile) & 0777, 'File permission was not correct: ' . decoct($perm));
 
         /* @noinspection PhpIncludeInspection */
         require $tmpFile;


### PR DESCRIPTION
Fixes #421 (tests were incorrectly using too restrictive permissions)