### PR TITLE
Added professional support notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ This library aims to provide abstraction for generating various kinds of
 You can learn about the proxy pattern and how to use the **ProxyManager** in the [docs](docs), which are also
 [compiled to HTML](http://ocramius.github.io/ProxyManager).
 
-## Help/Support
+## Professional Support
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Ocramius/ProxyManager?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[Professionally supported `ocramius/proxy-manager` is available through Tidelift](https://tidelift.com/subscription/pkg/packagist-ocramius-proxy-manager?utm_source=packagist-ocramius-proxy-manager&utm_medium=referral&utm_campaign=readme) .
+
+You can also contact the maintainer at ocramius@gmail.com for looking into issues related to this package
+in your private projects.
 
 ## Installation
 


### PR DESCRIPTION
As per Tidelift integration:

 * a link to the Tidelift subscription was provided
 * a way to contact the author for professional consulting was added

Gitter support was removed, since I'm no longer able to actively follow Gitter as well. I'm fine with new issues with questions being opened: easier to search, more useful to future users as well.

To other readers that are wondering about Tidelift: yes, it provides direct financial support to me for developing this package.