### PR TITLE
Improve usage of phpunit

### DIFF
--- a/tests/ProxyManagerTest/Autoloader/AutoloaderTest.php
+++ b/tests/ProxyManagerTest/Autoloader/AutoloaderTest.php
@@ -56,7 +56,7 @@ class AutoloaderTest extends TestCase
             ->expects(self::once())
             ->method('isProxyClassName')
             ->with($className)
-            ->will(self::returnValue(false));
+            ->willReturn(false);
 
         self::assertFalse($this->autoloadWithoutFurtherAutoloaders($className));
     }
@@ -72,12 +72,12 @@ class AutoloaderTest extends TestCase
             ->expects(self::once())
             ->method('isProxyClassName')
             ->with($className)
-            ->will(self::returnValue(true));
+            ->willReturn(true);
         $this
             ->fileLocator
             ->expects(self::once())
             ->method('getProxyFileName')
-            ->will(self::returnValue(__DIR__ . '/non-existing'));
+            ->willReturn(__DIR__ . '/non-existing');
 
         self::assertFalse($this->autoloadWithoutFurtherAutoloaders($className));
     }
@@ -98,7 +98,7 @@ class AutoloaderTest extends TestCase
         $namespace = 'Foo';
         $className = UniqueIdentifierGenerator::getIdentifier('Bar');
         $fqcn      = $namespace . '\\' . $className;
-        $fileName  = sys_get_temp_dir() . '/foo_' . uniqid() . '.php';
+        $fileName  = sys_get_temp_dir() . '/foo_' . uniqid('file', true) . '.php';
 
         file_put_contents($fileName, '<?php namespace ' . $namespace . '; class ' . $className . '{}');
 
@@ -107,12 +107,12 @@ class AutoloaderTest extends TestCase
             ->expects(self::once())
             ->method('isProxyClassName')
             ->with($fqcn)
-            ->will(self::returnValue(true));
+            ->willReturn(true);
         $this
             ->fileLocator
             ->expects(self::once())
             ->method('getProxyFileName')
-            ->will(self::returnValue($fileName));
+            ->willReturn($fileName);
 
         self::assertTrue($this->autoloadWithoutFurtherAutoloaders($fqcn));
         self::assertTrue(class_exists($fqcn, false));

--- a/tests/ProxyManagerTest/ConfigurationTest.php
+++ b/tests/ProxyManagerTest/ConfigurationTest.php
@@ -13,7 +13,6 @@ use ProxyManager\Inflector\ClassNameInflectorInterface;
 use ProxyManager\Signature\ClassSignatureGeneratorInterface;
 use ProxyManager\Signature\SignatureCheckerInterface;
 use ProxyManager\Signature\SignatureGeneratorInterface;
-use function is_dir;
 
 /**
  * Tests for {@see \ProxyManager\Configuration}
@@ -55,6 +54,7 @@ class ConfigurationTest extends TestCase
      */
     public function testSetGetClassNameInflector() : void
     {
+        /** @noinspection UnnecessaryAssertionInspection */
         self::assertInstanceOf(ClassNameInflectorInterface::class, $this->configuration->getClassNameInflector());
 
         /** @var ClassNameInflectorInterface $inflector */
@@ -78,6 +78,7 @@ class ConfigurationTest extends TestCase
      */
     public function testSetGetGeneratorStrategy() : void
     {
+        /** @noinspection UnnecessaryAssertionInspection */
         self::assertInstanceOf(GeneratorStrategyInterface::class, $this->configuration->getGeneratorStrategy());
 
         /** @var GeneratorStrategyInterface $strategy */
@@ -93,7 +94,7 @@ class ConfigurationTest extends TestCase
      */
     public function testSetGetProxiesTargetDir() : void
     {
-        self::assertTrue(is_dir($this->configuration->getProxiesTargetDir()));
+        self::assertDirectoryExists($this->configuration->getProxiesTargetDir());
 
         $this->configuration->setProxiesTargetDir(__DIR__);
         self::assertSame(__DIR__, $this->configuration->getProxiesTargetDir());
@@ -105,6 +106,7 @@ class ConfigurationTest extends TestCase
      */
     public function testSetGetProxyAutoloader() : void
     {
+        /** @noinspection UnnecessaryAssertionInspection */
         self::assertInstanceOf(AutoloaderInterface::class, $this->configuration->getProxyAutoloader());
 
         /** @var AutoloaderInterface $autoloader */
@@ -120,7 +122,8 @@ class ConfigurationTest extends TestCase
      */
     public function testSetGetSignatureGenerator() : void
     {
-        self::assertInstanceOf(SignatureGeneratorInterface::class, $this->configuration->getSignatureGenerator());
+        /** @noinspection UnnecessaryAssertionInspection */
+        self::assertInstanceOf(SignatureCheckerInterface::class, $this->configuration->getSignatureChecker());
 
         /** @var SignatureGeneratorInterface $signatureGenerator */
         $signatureGenerator = $this->createMock(SignatureGeneratorInterface::class);
@@ -135,6 +138,7 @@ class ConfigurationTest extends TestCase
      */
     public function testSetGetSignatureChecker() : void
     {
+        /** @noinspection UnnecessaryAssertionInspection */
         self::assertInstanceOf(SignatureCheckerInterface::class, $this->configuration->getSignatureChecker());
 
         /** @var SignatureCheckerInterface $signatureChecker */
@@ -150,11 +154,11 @@ class ConfigurationTest extends TestCase
      */
     public function testSetGetClassSignatureGenerator() : void
     {
+        /** @noinspection UnnecessaryAssertionInspection */
         self::assertInstanceOf(
             ClassSignatureGeneratorInterface::class,
             $this->configuration->getClassSignatureGenerator()
         );
-
         /** @var ClassSignatureGeneratorInterface $classSignatureGenerator */
         $classSignatureGenerator = $this->createMock(ClassSignatureGeneratorInterface::class);
 

--- a/tests/ProxyManagerTest/Exception/FileNotWritableExceptionTest.php
+++ b/tests/ProxyManagerTest/Exception/FileNotWritableExceptionTest.php
@@ -19,7 +19,6 @@ class FileNotWritableExceptionTest extends TestCase
     {
         $exception = FileNotWritableException::fromInvalidMoveOperation('/tmp/a', '/tmp/b');
 
-        self::assertInstanceOf(FileNotWritableException::class, $exception);
         self::assertSame(
             'Could not move file "/tmp/a" to location "/tmp/b": either the source file is not readable,'
             . ' or the destination is not writable',
@@ -31,7 +30,6 @@ class FileNotWritableExceptionTest extends TestCase
     {
         $exception = FileNotWritableException::fromNotWritableDirectory('/tmp/a');
 
-        self::assertInstanceOf(FileNotWritableException::class, $exception);
         self::assertSame(
             'Could not create temp file in directory "/tmp/a" '
             . 'either the directory does not exist, or it is not writable',

--- a/tests/ProxyManagerTest/Factory/AbstractBaseFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AbstractBaseFactoryTest.php
@@ -68,39 +68,33 @@ class AbstractBaseFactoryTest extends TestCase
         $this->classSignatureGenerator = $this->createMock(ClassSignatureGeneratorInterface::class);
 
         $configuration
-            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will(self::returnValue($this->classNameInflector));
+            ->willReturn($this->classNameInflector);
 
         $configuration
-            ->expects(self::any())
             ->method('getGeneratorStrategy')
-            ->will(self::returnValue($this->generatorStrategy));
+            ->willReturn($this->generatorStrategy);
 
         $configuration
-            ->expects(self::any())
             ->method('getProxyAutoloader')
-            ->will(self::returnValue($this->proxyAutoloader));
+            ->willReturn($this->proxyAutoloader);
 
         $configuration
-            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will(self::returnValue($this->signatureChecker));
+            ->willReturn($this->signatureChecker);
 
         $configuration
-            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will(self::returnValue($this->classSignatureGenerator));
+            ->willReturn($this->classSignatureGenerator);
 
         $this
             ->classNameInflector
-            ->expects(self::any())
             ->method('getUserClassName')
-            ->will(self::returnValue('stdClass'));
+            ->willReturn('stdClass');
 
         $this->factory = $this->getMockForAbstractClass(AbstractBaseFactory::class, [$configuration]);
 
-        $this->factory->expects(self::any())->method('getGenerator')->will(self::returnValue($this->generator));
+        $this->factory->method('getGenerator')->willReturn($this->generator);
     }
 
     public function testGeneratesClass() : void
@@ -112,10 +106,9 @@ class AbstractBaseFactoryTest extends TestCase
 
         $this
             ->classNameInflector
-            ->expects(self::any())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will(self::returnValue($generatedClass));
+            ->willReturn($generatedClass);
 
         $this
             ->generatorStrategy

--- a/tests/ProxyManagerTest/Factory/AccessInterceptorScopeLocalizerFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AccessInterceptorScopeLocalizerFactoryTest.php
@@ -51,21 +51,18 @@ class AccessInterceptorScopeLocalizerFactoryTest extends TestCase
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will(self::returnValue($this->inflector));
+            ->willReturn($this->inflector);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will(self::returnValue($this->signatureChecker));
+            ->willReturn($this->signatureChecker);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will(self::returnValue($this->classSignatureGenerator));
+            ->willReturn($this->classSignatureGenerator);
     }
 
     /**
@@ -96,7 +93,7 @@ class AccessInterceptorScopeLocalizerFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will(self::returnValue(AccessInterceptorValueHolderMock::class));
+            ->willReturn(AccessInterceptorValueHolderMock::class);
 
         $factory            = new AccessInterceptorScopeLocalizerFactory($this->config);
         $prefixInterceptors = [static function () : void {
@@ -132,8 +129,8 @@ class AccessInterceptorScopeLocalizerFactoryTest extends TestCase
         $generator      = $this->createMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->createMock(AutoloaderInterface::class);
 
-        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
-        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
+        $this->config->method('getGeneratorStrategy')->willReturn($generator);
+        $this->config->method('getProxyAutoloader')->willReturn($autoloader);
 
         $generator
             ->expects(self::once())
@@ -165,14 +162,14 @@ class AccessInterceptorScopeLocalizerFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will(self::returnValue($proxyClassName));
+            ->willReturn($proxyClassName);
 
         $this
             ->inflector
             ->expects(self::once())
             ->method('getUserClassName')
             ->with('stdClass')
-            ->will(self::returnValue(LazyLoadingMock::class));
+            ->willReturn(LazyLoadingMock::class);
 
         $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
         $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
@@ -189,7 +186,9 @@ class AccessInterceptorScopeLocalizerFactoryTest extends TestCase
         /** @var AccessInterceptorValueHolderMock $proxy */
         $proxy = $factory->createProxy($instance, $prefixInterceptors, $suffixInterceptors);
 
+        /** @noinspection UnnecessaryAssertionInspection */
         self::assertInstanceOf($proxyClassName, $proxy);
+
         self::assertSame($instance, $proxy->instance);
         self::assertSame($prefixInterceptors, $proxy->prefixInterceptors);
         self::assertSame($suffixInterceptors, $proxy->suffixInterceptors);

--- a/tests/ProxyManagerTest/Factory/AccessInterceptorValueHolderFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AccessInterceptorValueHolderFactoryTest.php
@@ -50,21 +50,18 @@ class AccessInterceptorValueHolderFactoryTest extends TestCase
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will(self::returnValue($this->inflector));
+            ->willReturn($this->inflector);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will(self::returnValue($this->signatureChecker));
+            ->willReturn($this->signatureChecker);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will(self::returnValue($this->classSignatureGenerator));
+            ->willReturn($this->classSignatureGenerator);
     }
 
     /**
@@ -95,7 +92,7 @@ class AccessInterceptorValueHolderFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will(self::returnValue(AccessInterceptorValueHolderMock::class));
+            ->willReturn(AccessInterceptorValueHolderMock::class);
 
         $factory            = new AccessInterceptorValueHolderFactory($this->config);
         $prefixInterceptors = [static function () : void {
@@ -131,8 +128,8 @@ class AccessInterceptorValueHolderFactoryTest extends TestCase
         $generator      = $this->createMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->createMock(AutoloaderInterface::class);
 
-        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
-        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
+        $this->config->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
             ->expects(self::once())
@@ -164,14 +161,14 @@ class AccessInterceptorValueHolderFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will(self::returnValue($proxyClassName));
+            ->willReturn($proxyClassName);
 
         $this
             ->inflector
             ->expects(self::once())
             ->method('getUserClassName')
             ->with('stdClass')
-            ->will(self::returnValue(EmptyClass::class));
+            ->willReturn(EmptyClass::class);
 
         $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
         $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));

--- a/tests/ProxyManagerTest/Factory/LazyLoadingGhostFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/LazyLoadingGhostFactoryTest.php
@@ -48,21 +48,18 @@ class LazyLoadingGhostFactoryTest extends TestCase
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will(self::returnValue($this->inflector));
+            ->willReturn($this->inflector);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will(self::returnValue($this->signatureChecker));
+            ->willReturn($this->signatureChecker);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will(self::returnValue($this->classSignatureGenerator));
+            ->willReturn($this->classSignatureGenerator);
     }
 
     /**
@@ -92,7 +89,7 @@ class LazyLoadingGhostFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with($className)
-            ->will(self::returnValue(LazyLoadingMock::class));
+            ->willReturn(LazyLoadingMock::class);
 
         $factory     = new LazyLoadingGhostFactory($this->config);
         $initializer = static function () : void {
@@ -120,8 +117,8 @@ class LazyLoadingGhostFactoryTest extends TestCase
         $generator      = $this->createMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->createMock(AutoloaderInterface::class);
 
-        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
-        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
+        $this->config->method('getGeneratorStrategy')->willReturn($generator);
+        $this->config->method('getProxyAutoloader')->willReturn($autoloader);
 
         $generator
             ->expects(self::once())
@@ -150,14 +147,14 @@ class LazyLoadingGhostFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with($className)
-            ->will(self::returnValue($proxyClassName));
+            ->willReturn($proxyClassName);
 
         $this
             ->inflector
             ->expects(self::once())
             ->method('getUserClassName')
             ->with($className)
-            ->will(self::returnValue(LazyLoadingMock::class));
+            ->willReturn(LazyLoadingMock::class);
 
         $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
         $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
@@ -168,7 +165,6 @@ class LazyLoadingGhostFactoryTest extends TestCase
         /** @var LazyLoadingMock $proxy */
         $proxy = $factory->createProxy($className, $initializer);
 
-        self::assertInstanceOf($proxyClassName, $proxy);
         self::assertSame($initializer, $proxy->initializer);
     }
 }

--- a/tests/ProxyManagerTest/Factory/LazyLoadingValueHolderFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/LazyLoadingValueHolderFactoryTest.php
@@ -50,21 +50,18 @@ class LazyLoadingValueHolderFactoryTest extends TestCase
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will(self::returnValue($this->inflector));
+            ->willReturn($this->inflector);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will(self::returnValue($this->signatureChecker));
+            ->willReturn($this->signatureChecker);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will(self::returnValue($this->classSignatureGenerator));
+            ->willReturn($this->classSignatureGenerator);
     }
 
     /**
@@ -94,7 +91,7 @@ class LazyLoadingValueHolderFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with($className)
-            ->will(self::returnValue(LazyLoadingMock::class));
+            ->willReturn(LazyLoadingMock::class);
 
         $factory     = new LazyLoadingValueHolderFactory($this->config);
         $initializer = static function () : void {
@@ -122,8 +119,8 @@ class LazyLoadingValueHolderFactoryTest extends TestCase
         $generator      = $this->createMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->createMock(AutoloaderInterface::class);
 
-        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
-        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
+        $this->config->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
             ->expects(self::once())
@@ -152,14 +149,14 @@ class LazyLoadingValueHolderFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with($className)
-            ->will(self::returnValue($proxyClassName));
+            ->willReturn($proxyClassName);
 
         $this
             ->inflector
             ->expects(self::once())
             ->method('getUserClassName')
             ->with($className)
-            ->will(self::returnValue(EmptyClass::class));
+            ->willReturn(EmptyClass::class);
 
         $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
         $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
@@ -170,7 +167,9 @@ class LazyLoadingValueHolderFactoryTest extends TestCase
         /** @var LazyLoadingMock $proxy */
         $proxy = $factory->createProxy($className, $initializer);
 
+        /** @noinspection UnnecessaryAssertionInspection */
         self::assertInstanceOf($proxyClassName, $proxy);
+
         self::assertSame($proxyClassName, get_class($proxy));
         self::assertSame($initializer, $proxy->initializer);
     }

--- a/tests/ProxyManagerTest/Factory/NullObjectFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/NullObjectFactoryTest.php
@@ -49,21 +49,18 @@ class NullObjectFactoryTest extends TestCase
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will(self::returnValue($this->inflector));
+            ->willReturn($this->inflector);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will(self::returnValue($this->signatureChecker));
+            ->willReturn($this->signatureChecker);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will(self::returnValue($this->classSignatureGenerator));
+            ->willReturn($this->classSignatureGenerator);
     }
 
     /**
@@ -82,7 +79,7 @@ class NullObjectFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will(self::returnValue(NullObjectMock::class));
+            ->willReturn(NullObjectMock::class);
 
         $factory = new NullObjectFactory($this->config);
         /** @var NullObjectMock $proxy */
@@ -107,8 +104,8 @@ class NullObjectFactoryTest extends TestCase
         $generator      = $this->createMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->createMock(AutoloaderInterface::class);
 
-        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
-        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
+        $this->config->method('getGeneratorStrategy')->will(self::returnValue($generator));
+        $this->config->method('getProxyAutoloader')->will(self::returnValue($autoloader));
 
         $generator
             ->expects(self::once())
@@ -137,22 +134,19 @@ class NullObjectFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with('stdClass')
-            ->will(self::returnValue($proxyClassName));
+            ->willReturn($proxyClassName);
 
         $this
             ->inflector
             ->expects(self::once())
             ->method('getUserClassName')
             ->with('stdClass')
-            ->will(self::returnValue(NullObjectMock::class));
+            ->willReturn(NullObjectMock::class);
 
         $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
         $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
 
         $factory = new NullObjectFactory($this->config);
-        /** @var NullObjectMock $proxy */
-        $proxy = $factory->createProxy($instance);
-
-        self::assertInstanceOf($proxyClassName, $proxy);
+        $factory->createProxy($instance);
     }
 }

--- a/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/BaseAdapterTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/BaseAdapterTest.php
@@ -40,13 +40,13 @@ class BaseAdapterTest extends TestCase
             ->expects(self::once())
             ->method('call')
             ->with('foobarbaz', ['tab' => 'taz'])
-            ->will(self::returnValue('baz'));
+            ->willReturn('baz');
 
         $adapter
             ->expects(self::once())
             ->method('getServiceName')
             ->with('foo', 'bar')
-            ->will(self::returnValue('foobarbaz'));
+            ->willReturn('foobarbaz');
 
         self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }
@@ -75,13 +75,13 @@ class BaseAdapterTest extends TestCase
             ->expects(self::once())
             ->method('call')
             ->with('mapped', ['tab' => 'taz'])
-            ->will(self::returnValue('baz'));
+            ->willReturn('baz');
 
         $adapter
             ->expects(self::once())
             ->method('getServiceName')
             ->with('foo', 'bar')
-            ->will(self::returnValue('foobarbaz'));
+            ->willReturn('foobarbaz');
 
         self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }

--- a/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/JsonRpcTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/JsonRpcTest.php
@@ -33,7 +33,7 @@ class JsonRpcTest extends TestCase
             ->expects(self::once())
             ->method('call')
             ->with('foo.bar', ['tab' => 'taz'])
-            ->will(self::returnValue('baz'));
+            ->willReturn('baz');
 
         self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }

--- a/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/SoapTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/SoapTest.php
@@ -33,7 +33,7 @@ class SoapTest extends TestCase
             ->expects(self::once())
             ->method('call')
             ->with('bar', ['tab' => 'taz'])
-            ->will(self::returnValue('baz'));
+            ->willReturn('baz');
 
         self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }

--- a/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/XmlRpcTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObject/Adapter/XmlRpcTest.php
@@ -33,7 +33,7 @@ class XmlRpcTest extends TestCase
             ->expects(self::once())
             ->method('call')
             ->with('foo.bar', ['tab' => 'taz'])
-            ->will(self::returnValue('baz'));
+            ->willReturn('baz');
 
         self::assertSame('baz', $adapter->call('foo', 'bar', ['tab' => 'taz']));
     }

--- a/tests/ProxyManagerTest/Factory/RemoteObjectFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/RemoteObjectFactoryTest.php
@@ -51,21 +51,18 @@ class RemoteObjectFactoryTest extends TestCase
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassNameInflector')
-            ->will(self::returnValue($this->inflector));
+            ->willReturn($this->inflector);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getSignatureChecker')
-            ->will(self::returnValue($this->signatureChecker));
+            ->willReturn($this->signatureChecker);
 
         $this
             ->config
-            ->expects(self::any())
             ->method('getClassSignatureGenerator')
-            ->will(self::returnValue($this->classSignatureGenerator));
+            ->willReturn($this->classSignatureGenerator);
     }
 
     /**
@@ -82,7 +79,7 @@ class RemoteObjectFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with(BaseInterface::class)
-            ->will(self::returnValue(RemoteObjectMock::class));
+            ->willReturn(RemoteObjectMock::class);
 
         /** @var AdapterInterface|MockObject $adapter */
         $adapter = $this->createMock(AdapterInterface::class);
@@ -108,8 +105,8 @@ class RemoteObjectFactoryTest extends TestCase
         $generator      = $this->createMock(GeneratorStrategyInterface::class);
         $autoloader     = $this->createMock(AutoloaderInterface::class);
 
-        $this->config->expects(self::any())->method('getGeneratorStrategy')->will(self::returnValue($generator));
-        $this->config->expects(self::any())->method('getProxyAutoloader')->will(self::returnValue($autoloader));
+        $this->config->method('getGeneratorStrategy')->willReturn($generator);
+        $this->config->method('getProxyAutoloader')->willReturn($autoloader);
 
         $generator
             ->expects(self::once())
@@ -142,14 +139,14 @@ class RemoteObjectFactoryTest extends TestCase
             ->expects(self::once())
             ->method('getProxyClassName')
             ->with(BaseInterface::class)
-            ->will(self::returnValue($proxyClassName));
+            ->willReturn($proxyClassName);
 
         $this
             ->inflector
             ->expects(self::once())
             ->method('getUserClassName')
             ->with(BaseInterface::class)
-            ->will(self::returnValue('stdClass'));
+            ->willReturn('stdClass');
 
         $this->signatureChecker->expects(self::atLeastOnce())->method('checkSignature');
         $this->classSignatureGenerator->expects(self::once())->method('addSignature')->will(self::returnArgument(0));
@@ -157,8 +154,6 @@ class RemoteObjectFactoryTest extends TestCase
         /** @var AdapterInterface $adapter */
         $adapter = $this->createMock(AdapterInterface::class);
         $factory = new RemoteObjectFactory($adapter, $this->config);
-        $proxy   = $factory->createProxy(BaseInterface::class);
-
-        self::assertInstanceOf($proxyClassName, $proxy);
+        $factory->createProxy(BaseInterface::class);
     }
 }

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
@@ -62,7 +62,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
 
         $callback = [$proxy, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
         self::assertSame($expectedValue, $callback(...array_values($params)));
 
         /** @var callable|MockObject $listener */
@@ -116,7 +116,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
         $proxy    = $proxyName::staticProxyConstructor($instance);
         $callback = [$proxy, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
 
         /** @var callable|MockObject $listener */
         $listener = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
@@ -169,7 +169,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
 
         $callback = [$proxy, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
         self::assertSame($expectedValue, $callback(...array_values($params)));
         $this->assertProxySynchronized($instance, $proxy);
     }
@@ -195,7 +195,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
         $callback = [$cloned, $method];
 
         $this->assertProxySynchronized($instance, $proxy);
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
         self::assertSame($expectedValue, $callback(...array_values($params)));
         $this->assertProxySynchronized($instance, $proxy);
     }
@@ -221,7 +221,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
     public function testPropertyWriteAccess(object $instance, AccessInterceptorInterface $proxy, string $publicProperty
     ) : void
     {
-        $newValue               = uniqid();
+        $newValue               = uniqid('value', true);
         $proxy->$publicProperty = $newValue;
 
         self::assertSame($newValue, $proxy->$publicProperty);
@@ -385,7 +385,7 @@ class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
      *
      * @return string[][]|object[][]|mixed[][][]
      */
-    public function getProxyMethods() : array
+    public static function getProxyMethods() : array
     {
         $selfHintParam = new ClassWithSelfHint();
         $empty         = new EmptyClass();

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
@@ -59,7 +59,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         $proxy    = $proxyName::staticProxyConstructor($instance);
         $callback = [$proxy, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
         self::assertSame($instance, $proxy->getWrappedValueHolderValue());
         self::assertSame($expectedValue, $callback(...array_values($params)));
 
@@ -112,7 +112,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         $proxy    = $proxyName::staticProxyConstructor($instance);
         $callback = [$proxy, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
 
         /** @var callable|MockObject $listener */
         $listener = $this->getMockBuilder(stdClass::class)->setMethods(['__invoke'])->getMock();
@@ -162,7 +162,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         $proxy    = unserialize(serialize($proxyName::staticProxyConstructor($instance)));
         $callback = [$proxy, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
         self::assertSame($expectedValue, $callback(...array_values($params)));
         self::assertEquals($instance, $proxy->getWrappedValueHolderValue());
     }
@@ -187,7 +187,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
         $cloned   = clone $proxy;
         $callback = [$cloned, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
         self::assertNotSame($proxy->getWrappedValueHolderValue(), $cloned->getWrappedValueHolderValue());
         self::assertSame($expectedValue, $callback(...array_values($params)));
         self::assertEquals($instance, $cloned->getWrappedValueHolderValue());
@@ -698,6 +698,7 @@ class AccessInterceptorValueHolderFunctionalTest extends TestCase
                         return;
                     }
 
+                    /** @noinspection IncrementDecrementOperationEquivalentInspection */
                     $instance->counter += 1;
                 },
             ]

--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -47,7 +47,7 @@ class FatalPreventionFunctionalTest extends TestCase
      */
     public function testCodeGeneration(string $generatorClass, string $className) : void
     {
-        $generatedClass    = new ClassGenerator(uniqid('generated'));
+        $generatedClass    = new ClassGenerator(uniqid('generated', true));
         $generatorStrategy = new EvaluatingGeneratorStrategy();
         /** @var ProxyGeneratorInterface $classGenerator */
         $classGenerator          = new $generatorClass();
@@ -125,10 +125,10 @@ class FatalPreventionFunctionalTest extends TestCase
 
                 $realPath = realpath($fileName);
 
-                self::assertInternalType('string', $realPath);
+                self::assertIsString($realPath);
 
                 foreach ($skippedPaths as $skippedPath) {
-                    self::assertInternalType('string', $skippedPath);
+                    self::assertIsString($skippedPath);
 
                     if (strpos($realPath, $skippedPath) === 0) {
                         // skip classes defined within ProxyManager, vendor or the test suite

--- a/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
@@ -79,7 +79,7 @@ class LazyLoadingGhostFunctionalTest extends TestCase
         $callProxyMethod = [$proxy, $method];
         $parameterValues = array_values($params);
 
-        self::assertInternalType('callable', $callProxyMethod);
+        self::assertIsCallable($callProxyMethod);
         self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
         self::assertTrue($proxy->isProxyInitialized());
     }
@@ -113,7 +113,7 @@ class LazyLoadingGhostFunctionalTest extends TestCase
         $callProxyMethod = [$proxy, $method];
         $parameterValues = array_values($params);
 
-        self::assertInternalType('callable', $callProxyMethod);
+        self::assertIsCallable($callProxyMethod);
         self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
         self::assertFalse($proxy->isProxyInitialized());
     }
@@ -144,7 +144,7 @@ class LazyLoadingGhostFunctionalTest extends TestCase
         $callProxyMethod = [$proxy, $method];
         $parameterValues = array_values($params);
 
-        self::assertInternalType('callable', $callProxyMethod);
+        self::assertIsCallable($callProxyMethod);
         self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
     }
 
@@ -173,7 +173,7 @@ class LazyLoadingGhostFunctionalTest extends TestCase
         $callProxyMethod = [$proxy, $method];
         $parameterValues = array_values($params);
 
-        self::assertInternalType('callable', $callProxyMethod);
+        self::assertIsCallable($callProxyMethod);
         self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
     }
 
@@ -748,7 +748,7 @@ class LazyLoadingGhostFunctionalTest extends TestCase
                 ));
         }
 
-        self::assertInternalType('callable', $initializerMatcher);
+        self::assertIsCallable($initializerMatcher);
 
         return static function (
             GhostObjectInterface $proxy,
@@ -1102,7 +1102,7 @@ class LazyLoadingGhostFunctionalTest extends TestCase
 
         $accessor = [$callerObject, $method];
 
-        self::assertInternalType('callable', $accessor);
+        self::assertIsCallable($accessor);
 
         self::assertFalse($proxy->isProxyInitialized());
         self::assertSame($expectedValue, $accessor($proxy));
@@ -1134,7 +1134,7 @@ class LazyLoadingGhostFunctionalTest extends TestCase
 
         $accessor = [$callerObject, $method];
 
-        self::assertInternalType('callable', $accessor);
+        self::assertIsCallable($accessor);
 
         self::assertTrue($proxy->isProxyInitialized());
         self::assertSame($expectedValue, $accessor($proxy));
@@ -1165,7 +1165,7 @@ class LazyLoadingGhostFunctionalTest extends TestCase
 
         $accessor = [$callerObject, $method];
 
-        self::assertInternalType('callable', $accessor);
+        self::assertIsCallable($accessor);
 
         self::assertTrue($proxy->isProxyInitialized());
         self::assertSame($expectedValue, $accessor($proxy));

--- a/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
@@ -97,7 +97,7 @@ class LazyLoadingValueHolderFunctionalTest extends TestCase
         $callProxyMethod = [$proxy, $method];
         $parameterValues = array_values($params);
 
-        self::assertInternalType('callable', $callProxyMethod);
+        self::assertIsCallable($callProxyMethod);
 
         self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
         self::assertEquals($instance, $proxy->getWrappedValueHolderValue());
@@ -129,7 +129,7 @@ class LazyLoadingValueHolderFunctionalTest extends TestCase
         $callProxyMethod = [$cloned, $method];
         $parameterValues = array_values($params);
 
-        self::assertInternalType('callable', $callProxyMethod);
+        self::assertIsCallable($callProxyMethod);
 
         self::assertSame($expectedValue, $callProxyMethod(...$parameterValues));
         self::assertEquals($instance, $cloned->getWrappedValueHolderValue());
@@ -385,7 +385,7 @@ class LazyLoadingValueHolderFunctionalTest extends TestCase
                 );
         }
 
-        self::assertInternalType('callable', $initializerMatcher);
+        self::assertIsCallable($initializerMatcher);
 
         return static function (
             & $wrappedObject,
@@ -557,7 +557,7 @@ class LazyLoadingValueHolderFunctionalTest extends TestCase
 
         $accessor = [$callerObject, $method];
 
-        self::assertInternalType('callable', $accessor);
+        self::assertIsCallable($accessor);
         self::assertFalse($proxy->isProxyInitialized());
         self::assertSame($expectedValue, $accessor($proxy));
         self::assertTrue($proxy->isProxyInitialized());

--- a/tests/ProxyManagerTest/Functional/NullObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/NullObjectFunctionalTest.php
@@ -231,7 +231,7 @@ class NullObjectFunctionalTest extends TestCase
         /** @var callable $method */
         $method = [$proxy, $methodName];
 
-        self::assertInternalType('callable', $method);
+        self::assertIsCallable($method);
 
         $parameterValues = array_values($parameters);
 

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -47,10 +47,9 @@ class RemoteObjectFunctionalTest extends TestCase
         $client = $this->getMockBuilder(Client::class)->setMethods(['call'])->getMock();
 
         $client
-            ->expects(self::any())
             ->method('call')
             ->with(self::stringEndsWith($method), $params)
-            ->will(self::returnValue($expectedValue));
+            ->willReturn($expectedValue);
 
         return new XmlRpcAdapter(
             $client,
@@ -68,10 +67,9 @@ class RemoteObjectFunctionalTest extends TestCase
         $client = $this->getMockBuilder(Client::class)->setMethods(['call'])->getMock();
 
         $client
-            ->expects(self::any())
             ->method('call')
             ->with(self::stringEndsWith($method), $params)
-            ->will(self::returnValue($expectedValue));
+            ->willReturn($expectedValue);
 
         return new JsonRpcAdapter(
             $client,
@@ -94,7 +92,7 @@ class RemoteObjectFunctionalTest extends TestCase
         $proxy    = $proxyName::staticProxyConstructor($this->getXmlRpcAdapter($expectedValue, $method, $params));
         $callback = [$proxy, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
         self::assertSame($expectedValue, $callback(...$params));
     }
 
@@ -113,7 +111,7 @@ class RemoteObjectFunctionalTest extends TestCase
         $proxy    = $proxyName::staticProxyConstructor($this->getJsonRpcAdapter($expectedValue, $method, $params));
         $callback = [$proxy, $method];
 
-        self::assertInternalType('callable', $callback);
+        self::assertIsCallable($callback);
         self::assertSame($expectedValue, $callback(...$params));
     }
 

--- a/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/MethodGeneratorTest.php
@@ -162,7 +162,7 @@ class MethodGeneratorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function returnTypeHintsProvider() : array
+    public static function returnTypeHintsProvider() : array
     {
         return [
             ['returnString', 'string'],

--- a/tests/ProxyManagerTest/Generator/Util/IdentifierSuffixerTest.php
+++ b/tests/ProxyManagerTest/Generator/Util/IdentifierSuffixerTest.php
@@ -56,7 +56,7 @@ class IdentifierSuffixerTest extends TestCase
     /**
      * @dataProvider getBaseIdentifierNames
      */
-    public function testGeneratedIdentifierSuffix(string $name) : void
+    public static function testGeneratedIdentifierSuffix(string $name) : void
     {
         // 5 generated characters are enough to keep idiots from tampering with these properties "the easy way"
         self::assertGreaterThan(5, strlen(IdentifierSuffixer::getIdentifier($name)));
@@ -67,7 +67,7 @@ class IdentifierSuffixerTest extends TestCase
      *
      * @return string[][]
      */
-    public function getBaseIdentifierNames() : array
+    public static function getBaseIdentifierNames() : array
     {
         return [
             [''],

--- a/tests/ProxyManagerTest/Generator/Util/UniqueIdentifierGeneratorTest.php
+++ b/tests/ProxyManagerTest/Generator/Util/UniqueIdentifierGeneratorTest.php
@@ -51,7 +51,7 @@ class UniqueIdentifierGeneratorTest extends TestCase
      *
      * @return string[][]
      */
-    public function getBaseIdentifierNames() : array
+    public static function getBaseIdentifierNames() : array
     {
         return [
             [''],

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -12,6 +12,7 @@ use ProxyManager\Generator\ClassGenerator;
 use ProxyManager\Generator\Util\UniqueIdentifierGenerator;
 use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 use const PATH_SEPARATOR;
+use const SCANDIR_SORT_ASCENDING;
 use function class_exists;
 use function clearstatcache;
 use function decoct;
@@ -62,7 +63,6 @@ class FileWriterGeneratorStrategyTest extends TestCase
         $fqcn      = $namespace . '\\' . $className;
 
         $locator
-            ->expects(self::any())
             ->method('getProxyFileName')
             ->with($fqcn)
             ->will(self::returnValue($tmpFile));
@@ -103,10 +103,9 @@ class FileWriterGeneratorStrategyTest extends TestCase
         $fqcn      = $namespace . '\\' . $className;
 
         $locator
-            ->expects(self::any())
             ->method('getProxyFileName')
             ->with($fqcn)
-            ->will(self::returnValue($tmpFile));
+            ->willReturn($tmpFile);
 
         $this->expectException(FileNotWritableException::class);
         $generator->generate(new ClassGenerator($fqcn));
@@ -123,10 +122,9 @@ class FileWriterGeneratorStrategyTest extends TestCase
         $fqcn      = $namespace . '\\' . $className;
 
         $locator
-            ->expects(self::any())
             ->method('getProxyFileName')
             ->with($fqcn)
-            ->will(self::returnValue($tmpFile));
+            ->willReturn($tmpFile);
 
         mkdir($tmpFile);
 
@@ -149,10 +147,9 @@ class FileWriterGeneratorStrategyTest extends TestCase
         $fqcn      = $namespace . '\\' . $className;
 
         $locator
-            ->expects(self::any())
             ->method('getProxyFileName')
             ->with($fqcn)
-            ->will(self::returnValue($tmpFile));
+            ->willReturn($tmpFile);
 
         mkdir($tmpFile);
 
@@ -163,7 +160,7 @@ class FileWriterGeneratorStrategyTest extends TestCase
         } catch (FileNotWritableException $exception) {
             rmdir($tmpFile);
 
-            self::assertEquals(['.', '..'], scandir($tmpDirPath));
+            self::assertEquals(['.', '..'], scandir($tmpDirPath, SCANDIR_SORT_ASCENDING));
         }
     }
 }

--- a/tests/ProxyManagerTest/Inflector/ClassNameInflectorTest.php
+++ b/tests/ProxyManagerTest/Inflector/ClassNameInflectorTest.php
@@ -97,7 +97,7 @@ class ClassNameInflectorTest extends TestCase
      *
      * @return string[][]
      */
-    public function getClassNames() : array
+    public static function getClassNames() : array
     {
         return [
             ['Foo', 'ProxyNS\\' . ClassNameInflectorInterface::PROXY_MARKER . '\\Foo\\%s'],
@@ -110,7 +110,7 @@ class ClassNameInflectorTest extends TestCase
      *
      * @return mixed[][]
      */
-    public function getClassAndParametersCombinations() : array
+    public static function getClassAndParametersCombinations() : array
     {
         return [
             ['Foo', []],

--- a/tests/ProxyManagerTest/Inflector/Util/ParameterEncoderTest.php
+++ b/tests/ProxyManagerTest/Inflector/Util/ParameterEncoderTest.php
@@ -32,7 +32,7 @@ class ParameterEncoderTest extends TestCase
     }
 
     /** @return mixed[][] */
-    public function getParameters() : array
+    public static function getParameters() : array
     {
         return [
             [[]],

--- a/tests/ProxyManagerTest/Inflector/Util/ParameterHasherTest.php
+++ b/tests/ProxyManagerTest/Inflector/Util/ParameterHasherTest.php
@@ -28,7 +28,7 @@ class ParameterHasherTest extends TestCase
     }
 
     /** @return mixed[][][]|string[][] */
-    public function getParameters() : array
+    public static function getParameters() : array
     {
         return [
             [[], '40cd750bba9870f18aada2478b24840a'],

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodPrefixInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodPrefixInterceptorTest.php
@@ -25,7 +25,7 @@ class SetMethodPrefixInterceptorTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffix */
         $suffix = $this->createMock(PropertyGenerator::class);
 
-        $suffix->expects(self::once())->method('getName')->will(self::returnValue('foo'));
+        $suffix->expects(self::once())->method('getName')->willReturn('foo');
 
         $setter = new SetMethodPrefixInterceptor($suffix);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodSuffixInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptor/MethodGenerator/SetMethodSuffixInterceptorTest.php
@@ -25,7 +25,7 @@ class SetMethodSuffixInterceptorTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffix */
         $suffix = $this->createMock(PropertyGenerator::class);
 
-        $suffix->expects(self::once())->method('getName')->will(self::returnValue('foo'));
+        $suffix->expects(self::once())->method('getName')->willReturn('foo');
 
         $setter = new SetMethodSuffixInterceptor($suffix);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyPropertiesTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/BindProxyPropertiesTest.php
@@ -36,8 +36,8 @@ class BindProxyPropertiesTest extends TestCase
         $this->prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $this->suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $this->prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $this->suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $this->prefixInterceptors->method('getName')->willReturn('pre');
+        $this->suffixInterceptors->method('getName')->willReturn('post');
     }
 
     public function testSignature() : void

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/InterceptedMethodTest.php
@@ -37,8 +37,8 @@ class InterceptedMethodTest extends TestCase
         $this->prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $this->suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $this->prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $this->suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $this->prefixInterceptors->method('getName')->willReturn('pre');
+        $this->suffixInterceptors->method('getName')->willReturn('post');
     }
 
     public function testBodyStructure() : void

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicCloneTest.php
@@ -30,8 +30,8 @@ class MagicCloneTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicClone = new MagicClone($reflection, $prefixInterceptors, $suffixInterceptors);
 
@@ -51,8 +51,8 @@ class MagicCloneTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicClone = new MagicClone($reflection, $prefixInterceptors, $suffixInterceptors);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGetTest.php
@@ -30,8 +30,8 @@ class MagicGetTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicGet = new MagicGet(
             $reflection,
@@ -55,8 +55,8 @@ class MagicGetTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicGet = new MagicGet(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIssetTest.php
@@ -30,8 +30,8 @@ class MagicIssetTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicIsset = new MagicIsset(
             $reflection,
@@ -55,8 +55,8 @@ class MagicIssetTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicIsset = new MagicIsset(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSetTest.php
@@ -30,8 +30,8 @@ class MagicSetTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicGet = new MagicSet(
             $reflection,
@@ -55,8 +55,8 @@ class MagicSetTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicGet = new MagicSet(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSleepTest.php
@@ -30,8 +30,8 @@ class MagicSleepTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicGet = new MagicSleep(
             $reflection,
@@ -55,8 +55,8 @@ class MagicSleepTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicGet = new MagicSleep(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnsetTest.php
@@ -30,8 +30,8 @@ class MagicUnsetTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicGet = new MagicUnset(
             $reflection,
@@ -55,8 +55,8 @@ class MagicUnsetTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicGet = new MagicUnset(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/StaticProxyConstructorTest.php
@@ -34,8 +34,8 @@ class StaticProxyConstructorTest extends TestCase
         $this->prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $this->suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $this->prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $this->suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $this->prefixInterceptors->method('getName')->willReturn('pre');
+        $this->suffixInterceptors->method('getName')->willReturn('post');
     }
 
     public function testSignature() : void

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/Util/InterceptorGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/Util/InterceptorGeneratorTest.php
@@ -35,12 +35,12 @@ class InterceptorGeneratorTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $bar->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $baz->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $method->expects(self::any())->method('getName')->will(self::returnValue('fooMethod'));
-        $method->expects(self::any())->method('getParameters')->will(self::returnValue([$bar, $baz]));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $bar->method('getName')->willReturn('bar');
+        $baz->method('getName')->willReturn('baz');
+        $method->method('getName')->willReturn('fooMethod');
+        $method->method('getParameters')->will(self::returnValue([$bar, $baz]));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         // @codingStandardsIgnoreStart
         $expected = <<<'PHP'
@@ -93,12 +93,12 @@ PHP;
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $bar->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $baz->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $method->expects(self::any())->method('getName')->will(self::returnValue('fooMethod'));
-        $method->expects(self::any())->method('getParameters')->will(self::returnValue([$bar, $baz]));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $bar->method('getName')->willReturn('bar');
+        $baz->method('getName')->willReturn('baz');
+        $method->method('getName')->willReturn('fooMethod');
+        $method->method('getParameters')->will(self::returnValue([$bar, $baz]));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         // @codingStandardsIgnoreStart
         $expected = <<<'PHP'
@@ -154,12 +154,12 @@ PHP;
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $bar->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $baz->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $method->expects(self::any())->method('getName')->will(self::returnValue('fooMethod'));
-        $method->expects(self::any())->method('getParameters')->will(self::returnValue([$bar, $baz]));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $bar->method('getName')->willReturn('bar');
+        $baz->method('getName')->willReturn('baz');
+        $method->method('getName')->willReturn('fooMethod');
+        $method->method('getParameters')->will(self::returnValue([$bar, $baz]));
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         // @codingStandardsIgnoreStart
         $expected = <<<'PHP'

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethodTest.php
@@ -30,9 +30,9 @@ class InterceptedMethodTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $valueHolder->method('getName')->willReturn('foo');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $method = InterceptedMethod::generateMethod(
             new MethodReflection(BaseClass::class, 'publicByReferenceParameterMethod'),

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicCloneTest.php
@@ -31,9 +31,9 @@ class MagicCloneTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $valueHolder->method('getName')->willReturn('bar');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $magicClone = new MagicClone($reflection, $valueHolder, $prefixInterceptors, $suffixInterceptors);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGetTest.php
@@ -37,10 +37,10 @@ class MagicGetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $valueHolder->method('getName')->willReturn('bar');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
+        $publicProperties->method('isEmpty')->willReturn(false);
 
         $magicGet = new MagicGet(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIssetTest.php
@@ -38,10 +38,10 @@ class MagicIssetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $valueHolder->method('getName')->willReturn('bar');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
+        $publicProperties->method('isEmpty')->willReturn(false);
 
         $magicIsset = new MagicIsset(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSetTest.php
@@ -38,10 +38,10 @@ class MagicSetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $valueHolder->method('getName')->willReturn('bar');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
+        $publicProperties->method('isEmpty')->willReturn(false);
 
         $magicSet = new MagicSet(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnsetTest.php
@@ -38,10 +38,10 @@ class MagicUnsetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
+        $valueHolder->method('getName')->willReturn('bar');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
+        $publicProperties->method('isEmpty')->willReturn(false);
 
         $magicUnset = new MagicUnset(
             $reflection,

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/StaticProxyConstructorTest.php
@@ -30,9 +30,9 @@ class StaticProxyConstructorTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $valueHolder->method('getName')->willReturn('foo');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $constructor = new StaticProxyConstructor(
             new ReflectionClass(
@@ -73,9 +73,9 @@ return $instance;',
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $valueHolder->method('getName')->willReturn('foo');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $constructor = new StaticProxyConstructor(
             new ReflectionClass(EmptyClass::class),
@@ -111,9 +111,9 @@ return $instance;',
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $valueHolder->method('getName')->willReturn('foo');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         $constructor = new StaticProxyConstructor(
             new ReflectionClass(ClassWithMixedProperties::class),

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/Util/InterceptorGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/Util/InterceptorGeneratorTest.php
@@ -37,13 +37,13 @@ class InterceptorGeneratorTest extends TestCase
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $bar->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $baz->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $method->expects(self::any())->method('getName')->will(self::returnValue('fooMethod'));
-        $method->expects(self::any())->method('getParameters')->will(self::returnValue([$bar, $baz]));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $bar->method('getName')->willReturn('bar');
+        $baz->method('getName')->willReturn('baz');
+        $method->method('getName')->willReturn('fooMethod');
+        $method->method('getParameters')->will(self::returnValue([$bar, $baz]));
+        $valueHolder->method('getName')->willReturn('foo');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         // @codingStandardsIgnoreStart
         $expected = <<<'PHP'
@@ -99,13 +99,13 @@ PHP;
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $bar->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $baz->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $method->expects(self::any())->method('getName')->will(self::returnValue('fooMethod'));
-        $method->expects(self::any())->method('getParameters')->will(self::returnValue([$bar, $baz]));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $bar->method('getName')->willReturn('bar');
+        $baz->method('getName')->willReturn('baz');
+        $method->method('getName')->willReturn('fooMethod');
+        $method->method('getParameters')->will(self::returnValue([$bar, $baz]));
+        $valueHolder->method('getName')->willReturn('foo');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         // @codingStandardsIgnoreStart
         $expected = <<<'PHP'
@@ -164,13 +164,13 @@ PHP;
         /** @var PropertyGenerator|MockObject $suffixInterceptors */
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
-        $bar->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $baz->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $method->expects(self::any())->method('getName')->will(self::returnValue('fooMethod'));
-        $method->expects(self::any())->method('getParameters')->will(self::returnValue([$bar, $baz]));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $prefixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('pre'));
-        $suffixInterceptors->expects(self::any())->method('getName')->will(self::returnValue('post'));
+        $bar->method('getName')->willReturn('bar');
+        $baz->method('getName')->willReturn('baz');
+        $method->method('getName')->willReturn('fooMethod');
+        $method->method('getParameters')->will(self::returnValue([$bar, $baz]));
+        $valueHolder->method('getName')->willReturn('foo');
+        $prefixInterceptors->method('getName')->willReturn('pre');
+        $suffixInterceptors->method('getName')->willReturn('post');
 
         // @codingStandardsIgnoreStart
         $expected = <<<'PHP'

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoading/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoading/MethodGenerator/StaticProxyConstructorTest.php
@@ -25,7 +25,7 @@ class StaticProxyConstructorTest extends TestCase
         /** @var PropertyGenerator|MockObject $initializer */
         $initializer = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initializer->method('getName')->willReturn('foo');
 
         $constructor = new StaticProxyConstructor(
             $initializer,

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
@@ -28,8 +28,8 @@ class CallInitializerTest extends TestCase
         /** @var PropertyGenerator|MockObject $initializationTracker */
         $initializationTracker = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('init'));
-        $initializationTracker->expects(self::any())->method('getName')->will(self::returnValue('track'));
+        $initializer->method('getName')->willReturn('init');
+        $initializationTracker->method('getName')->willReturn('track');
 
         $callInitializer = new CallInitializer(
             $initializer,
@@ -105,8 +105,8 @@ return $result;';
         /** @var PropertyGenerator|MockObject $initializationTracker */
         $initializationTracker = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('init'));
-        $initializationTracker->expects(self::any())->method('getName')->will(self::returnValue('track'));
+        $initializer->method('getName')->willReturn('init');
+        $initializationTracker->method('getName')->willReturn('track');
 
         $callInitializer = new CallInitializer(
             $initializer,

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/GetProxyInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/GetProxyInitializerTest.php
@@ -25,7 +25,7 @@ class GetProxyInitializerTest extends TestCase
         /** @var PropertyGenerator|MockObject $initializer */
         $initializer = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initializer->method('getName')->willReturn('foo');
 
         $getter = new GetProxyInitializer($initializer);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/InitializeProxyTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/InitializeProxyTest.php
@@ -27,8 +27,8 @@ class InitializeProxyTest extends TestCase
         /** @var MethodGenerator|MockObject $initCall */
         $initCall = $this->createMock(MethodGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $initCall->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $initCall->method('getName')->willReturn('bar');
 
         $initializeProxy = new InitializeProxy($initializer, $initCall);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/IsProxyInitializedTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/IsProxyInitializedTest.php
@@ -24,7 +24,7 @@ class IsProxyInitializedTest extends TestCase
         /** @var PropertyGenerator|MockObject $initializer */
         $initializer = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initializer->method('getName')->willReturn('foo');
 
         $isProxyInitialized = new IsProxyInitialized($initializer);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicCloneTest.php
@@ -30,8 +30,8 @@ class MagicCloneTest extends TestCase
         /** @var MethodGenerator|MockObject $initCall */
         $initCall = $this->createMock(MethodGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $initCall->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $initCall->method('getName')->willReturn('bar');
 
         $magicClone = new MagicClone($reflection, $initializer, $initCall);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
@@ -129,13 +129,13 @@ PHP;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $this->initMethod->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $this->publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $this->publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $this->protectedProperties->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $this->privateProperties->expects(self::any())->method('getName')->will(self::returnValue('tab'));
-        $this->initializationTracker->expects(self::any())->method('getName')->will(self::returnValue('init'));
+        $this->initializer->method('getName')->willReturn('foo');
+        $this->initMethod->method('getName')->willReturn('baz');
+        $this->publicProperties->method('isEmpty')->willReturn(false);
+        $this->publicProperties->method('getName')->willReturn('bar');
+        $this->protectedProperties->method('getName')->willReturn('baz');
+        $this->privateProperties->method('getName')->willReturn('tab');
+        $this->initializationTracker->method('getName')->willReturn('init');
     }
 
     /**

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIssetTest.php
@@ -116,12 +116,12 @@ PHP;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $this->initMethod->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $this->publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $this->publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $this->protectedProperties->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $this->privateProperties->expects(self::any())->method('getName')->will(self::returnValue('tab'));
+        $this->initializer->method('getName')->willReturn('foo');
+        $this->initMethod->method('getName')->willReturn('baz');
+        $this->publicProperties->method('isEmpty')->willReturn(false);
+        $this->publicProperties->method('getName')->willReturn('bar');
+        $this->protectedProperties->method('getName')->willReturn('baz');
+        $this->privateProperties->method('getName')->willReturn('tab');
     }
 
     /**

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSetTest.php
@@ -117,12 +117,12 @@ PHP;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $this->initMethod->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $this->publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $this->publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $this->protectedProperties->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $this->privateProperties->expects(self::any())->method('getName')->will(self::returnValue('tab'));
+        $this->initializer->method('getName')->willReturn('foo');
+        $this->initMethod->method('getName')->willReturn('baz');
+        $this->publicProperties->method('isEmpty')->willReturn(false);
+        $this->publicProperties->method('getName')->willReturn('bar');
+        $this->protectedProperties->method('getName')->willReturn('baz');
+        $this->privateProperties->method('getName')->willReturn('tab');
     }
 
     /**

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSleepTest.php
@@ -30,8 +30,8 @@ class MagicSleepTest extends TestCase
         /** @var MethodGenerator|MockObject $initMethod */
         $initMethod = $this->createMock(MethodGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $initMethod->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $initMethod->method('getName')->willReturn('bar');
 
         $magicSleep = new MagicSleep($reflection, $initializer, $initMethod);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnsetTest.php
@@ -122,12 +122,12 @@ PHP;
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $this->initMethod->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $this->publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $this->publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $this->protectedProperties->expects(self::any())->method('getName')->will(self::returnValue('baz'));
-        $this->privateProperties->expects(self::any())->method('getName')->will(self::returnValue('tab'));
+        $this->initializer->method('getName')->willReturn('foo');
+        $this->initMethod->method('getName')->willReturn('baz');
+        $this->publicProperties->method('isEmpty')->willReturn(false);
+        $this->publicProperties->method('getName')->willReturn('bar');
+        $this->protectedProperties->method('getName')->willReturn('baz');
+        $this->privateProperties->method('getName')->willReturn('tab');
     }
 
     /**

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/SetProxyInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/SetProxyInitializerTest.php
@@ -26,7 +26,7 @@ class SetProxyInitializerTest extends TestCase
         /** @var PropertyGenerator|MockObject $initializer */
         $initializer = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initializer->method('getName')->willReturn('foo');
 
         $setter     = new SetProxyInitializer($initializer);
         $parameters = $setter->getParameters();

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/GetProxyInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/GetProxyInitializerTest.php
@@ -25,7 +25,7 @@ class GetProxyInitializerTest extends TestCase
         /** @var PropertyGenerator|MockObject $initializer */
         $initializer = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initializer->method('getName')->willReturn('foo');
 
         $getter = new GetProxyInitializer($initializer);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/InitializeProxyTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/InitializeProxyTest.php
@@ -26,8 +26,8 @@ class InitializeProxyTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
 
         $initializeProxy = new InitializeProxy($initializer, $valueHolder);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/IsProxyInitializedTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/IsProxyInitializedTest.php
@@ -24,7 +24,7 @@ class IsProxyInitializedTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $valueHolder->method('getName')->willReturn('bar');
 
         $isProxyInitialized = new IsProxyInitialized($valueHolder);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptorTest.php
@@ -28,8 +28,8 @@ class LazyLoadingMethodInterceptorTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
 
         $reflection = new MethodReflection(BaseClass::class, 'publicByReferenceParameterMethod');
         $method     = LazyLoadingMethodInterceptor::generateMethod($reflection, $initializer, $valueHolder);
@@ -55,10 +55,10 @@ class LazyLoadingMethodInterceptorTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initializer->method('getName')->willReturn('foo');
 
         $method = LazyLoadingMethodInterceptor::generateMethod($reflectionMethod, $initializer, $valueHolder);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicCloneTest.php
@@ -29,8 +29,8 @@ class MagicCloneTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
 
         $magicClone = new MagicClone($reflection, $initializer, $valueHolder);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGetTest.php
@@ -36,10 +36,10 @@ class MagicGetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
+        $publicProperties->method('isEmpty')->willReturn(false);
+        $publicProperties->method('getName')->willReturn('bar');
 
         $magicGet = new MagicGet($reflection, $initializer, $valueHolder, $publicProperties);
 
@@ -71,10 +71,10 @@ class MagicGetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
+        $publicProperties->method('isEmpty')->willReturn(false);
+        $publicProperties->method('getName')->willReturn('bar');
 
         $magicGet = new MagicGet($reflection, $initializer, $valueHolder, $publicProperties);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIssetTest.php
@@ -35,10 +35,10 @@ class MagicIssetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
+        $publicProperties->method('isEmpty')->willReturn(false);
+        $publicProperties->method('getName')->willReturn('bar');
 
         $magicIsset = new MagicIsset($reflection, $initializer, $valueHolder, $publicProperties);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSetTest.php
@@ -34,10 +34,10 @@ class MagicSetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
+        $publicProperties->method('isEmpty')->willReturn(false);
+        $publicProperties->method('getName')->willReturn('bar');
 
         $magicSet = new MagicSet($reflection, $initializer, $valueHolder, $publicProperties);
 
@@ -68,10 +68,10 @@ class MagicSetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
+        $publicProperties->method('isEmpty')->willReturn(false);
+        $publicProperties->method('getName')->willReturn('bar');
 
         $magicSet = new MagicSet($reflection, $initializer, $valueHolder, $publicProperties);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSleepTest.php
@@ -29,8 +29,8 @@ class MagicSleepTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
 
         $magicSleep = new MagicSleep($reflection, $initializer, $valueHolder);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnsetTest.php
@@ -34,10 +34,10 @@ class MagicUnsetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
+        $publicProperties->method('isEmpty')->willReturn(false);
+        $publicProperties->method('getName')->willReturn('bar');
 
         $magicIsset = new MagicUnset($reflection, $initializer, $valueHolder, $publicProperties);
 
@@ -68,10 +68,10 @@ class MagicUnsetTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
-        $publicProperties->expects(self::any())->method('isEmpty')->will(self::returnValue(false));
-        $publicProperties->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $initializer->method('getName')->willReturn('foo');
+        $valueHolder->method('getName')->willReturn('bar');
+        $publicProperties->method('isEmpty')->willReturn(false);
+        $publicProperties->method('getName')->willReturn('bar');
 
         $magicIsset = new MagicUnset($reflection, $initializer, $valueHolder, $publicProperties);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/SetProxyInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/SetProxyInitializerTest.php
@@ -26,7 +26,7 @@ class SetProxyInitializerTest extends TestCase
         /** @var PropertyGenerator|MockObject $initializer */
         $initializer = $this->createMock(PropertyGenerator::class);
 
-        $initializer->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $initializer->method('getName')->willReturn('foo');
 
         $setter     = new SetProxyInitializer($initializer);
         $parameters = $setter->getParameters();

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
@@ -74,7 +74,7 @@ class NullObjectGeneratorTest extends AbstractProxyGeneratorTest
 
             $callback = [$proxy, $method->getName()];
 
-            self::assertInternalType('callable', $callback);
+            self::assertIsCallable($callback);
             self::assertNull($callback());
         }
     }

--- a/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/PublicPropertiesMapTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/PropertyGenerator/PublicPropertiesMapTest.php
@@ -26,7 +26,7 @@ class PublicPropertiesMapTest extends TestCase
             Properties::fromReflectionClass(new ReflectionClass(EmptyClass::class))
         );
 
-        self::assertInternalType('array', $publicProperties->getDefaultValue()->getValue());
+        self::assertIsArray($publicProperties->getDefaultValue()->getValue());
         self::assertEmpty($publicProperties->getDefaultValue()->getValue());
         self::assertTrue($publicProperties->isStatic());
         self::assertSame('private', $publicProperties->getVisibility());
@@ -39,7 +39,7 @@ class PublicPropertiesMapTest extends TestCase
             Properties::fromReflectionClass(new ReflectionClass(ClassWithPublicProperties::class))
         );
 
-        self::assertInternalType('array', $publicProperties->getDefaultValue()->getValue());
+        self::assertIsArray($publicProperties->getDefaultValue()->getValue());
         self::assertCount(10, $publicProperties->getDefaultValue()->getValue());
         self::assertTrue($publicProperties->isStatic());
         self::assertSame('private', $publicProperties->getVisibility());

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicGetTest.php
@@ -26,7 +26,7 @@ class MagicGetTest extends TestCase
         $reflection = new ReflectionClass(EmptyClass::class);
         /** @var PropertyGenerator|MockObject $adapter */
         $adapter = $this->createMock(PropertyGenerator::class);
-        $adapter->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $adapter->method('getName')->willReturn('foo');
 
         $magicGet = new MagicGet($reflection, $adapter);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicIssetTest.php
@@ -26,7 +26,7 @@ class MagicIssetTest extends TestCase
         $reflection = new ReflectionClass(EmptyClass::class);
         /** @var PropertyGenerator|MockObject $adapter */
         $adapter = $this->createMock(PropertyGenerator::class);
-        $adapter->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $adapter->method('getName')->willReturn('foo');
 
         $magicGet = new MagicIsset($reflection, $adapter);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicSetTest.php
@@ -26,7 +26,7 @@ class MagicSetTest extends TestCase
         $reflection = new ReflectionClass(EmptyClass::class);
         /** @var PropertyGenerator|MockObject $adapter */
         $adapter = $this->createMock(PropertyGenerator::class);
-        $adapter->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $adapter->method('getName')->willReturn('foo');
 
         $magicGet = new MagicSet($reflection, $adapter);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicUnsetTest.php
@@ -26,7 +26,7 @@ class MagicUnsetTest extends TestCase
         $reflection = new ReflectionClass(EmptyClass::class);
         /** @var PropertyGenerator|MockObject $adapter */
         $adapter = $this->createMock(PropertyGenerator::class);
-        $adapter->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $adapter->method('getName')->willReturn('foo');
 
         $magicGet = new MagicUnset($reflection, $adapter);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
@@ -26,7 +26,7 @@ class RemoteObjectMethodTest extends TestCase
     {
         /** @var PropertyGenerator|MockObject $adapter */
         $adapter = $this->createMock(PropertyGenerator::class);
-        $adapter->expects(self::any())->method('getName')->will(self::returnValue('adapter'));
+        $adapter->method('getName')->willReturn('adapter');
 
         $reflectionMethod = new MethodReflection(
             BaseClass::class,
@@ -56,7 +56,7 @@ class RemoteObjectMethodTest extends TestCase
     {
         /** @var PropertyGenerator|MockObject $adapter */
         $adapter = $this->createMock(PropertyGenerator::class);
-        $adapter->expects(self::any())->method('getName')->will(self::returnValue('adapter'));
+        $adapter->method('getName')->willReturn('adapter');
 
         $reflectionMethod = new MethodReflection(BaseClass::class, 'publicArrayHintedMethod');
 
@@ -83,7 +83,7 @@ class RemoteObjectMethodTest extends TestCase
     {
         /** @var PropertyGenerator|MockObject $adapter */
         $adapter = $this->createMock(PropertyGenerator::class);
-        $adapter->expects(self::any())->method('getName')->will(self::returnValue('adapter'));
+        $adapter->method('getName')->willReturn('adapter');
 
         $reflectionMethod = new MethodReflection(BaseClass::class, 'publicMethod');
 

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/StaticProxyConstructorTest.php
@@ -24,7 +24,7 @@ class StaticProxyConstructorTest extends TestCase
         /** @var PropertyGenerator|MockObject $adapter */
         $adapter = $this->createMock(PropertyGenerator::class);
 
-        $adapter->expects(self::any())->method('getName')->will(self::returnValue('adapter'));
+        $adapter->method('getName')->willReturn('adapter');
 
         $constructor = new StaticProxyConstructor(
             new ReflectionClass(ClassWithMixedProperties::class),

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/ConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/ConstructorTest.php
@@ -27,7 +27,7 @@ class ConstructorTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->method('getName')->willReturn('foo');
 
         $constructor = Constructor::generateMethod(
             new ReflectionClass(
@@ -57,7 +57,7 @@ unset($this->bar, $this->baz);
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->method('getName')->willReturn('foo');
 
         $constructor = Constructor::generateMethod(
             new ReflectionClass(EmptyClass::class),
@@ -82,7 +82,7 @@ if (! $this->foo) {
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->method('getName')->willReturn('foo');
 
         $constructor = Constructor::generateMethod(new ReflectionClass(ClassWithMixedProperties::class), $valueHolder);
 
@@ -111,7 +111,7 @@ unset($this->publicProperty0, $this->publicProperty1, $this->publicProperty2, $t
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->method('getName')->willReturn('foo');
 
         $constructor = Constructor::generateMethod(
             new ReflectionClass(ClassWithVariadicConstructorArgument::class),

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/GetWrappedValueHolderValueTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/GetWrappedValueHolderValueTest.php
@@ -25,7 +25,7 @@ class GetWrappedValueHolderValueTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('foo'));
+        $valueHolder->method('getName')->willReturn('foo');
 
         $getter = new GetWrappedValueHolderValue($valueHolder);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/MagicSleepTest.php
@@ -27,7 +27,7 @@ class MagicSleepTest extends TestCase
         /** @var PropertyGenerator|MockObject $valueHolder */
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
-        $valueHolder->expects(self::any())->method('getName')->will(self::returnValue('bar'));
+        $valueHolder->method('getName')->willReturn('bar');
 
         $magicSleep = new MagicSleep($reflection, $valueHolder);
 

--- a/tests/ProxyManagerTest/Signature/ClassSignatureGeneratorTest.php
+++ b/tests/ProxyManagerTest/Signature/ClassSignatureGeneratorTest.php
@@ -51,17 +51,15 @@ class ClassSignatureGeneratorTest extends TestCase
 
         $this
             ->signatureGenerator
-            ->expects(self::any())
             ->method('generateSignature')
             ->with(['foo' => 'bar'])
-            ->will(self::returnValue('valid-signature'));
+            ->willReturn('valid-signature');
 
         $this
             ->signatureGenerator
-            ->expects(self::any())
             ->method('generateSignatureKey')
             ->with(['foo' => 'bar'])
-            ->will(self::returnValue('PropertyName'));
+            ->willReturn('PropertyName');
 
         $this->classSignatureGenerator->addSignature($classGenerator, ['foo' => 'bar']);
     }

--- a/tests/ProxyManagerTest/Signature/Exception/InvalidSignatureExceptionTest.php
+++ b/tests/ProxyManagerTest/Signature/Exception/InvalidSignatureExceptionTest.php
@@ -25,8 +25,6 @@ class InvalidSignatureExceptionTest extends TestCase
             'expected-signature'
         );
 
-        self::assertInstanceOf(InvalidSignatureException::class, $exception);
-
         self::assertSame(
             'Found signature "blah" for class "'
             . self::class

--- a/tests/ProxyManagerTest/Signature/Exception/MissingSignatureExceptionTest.php
+++ b/tests/ProxyManagerTest/Signature/Exception/MissingSignatureExceptionTest.php
@@ -24,8 +24,6 @@ class MissingSignatureExceptionTest extends TestCase
             'expected-signature'
         );
 
-        self::assertInstanceOf(MissingSignatureException::class, $exception);
-
         self::assertSame(
             'No signature found for class "'
             . self::class

--- a/tests/ProxyManagerTest/Signature/SignatureCheckerTest.php
+++ b/tests/ProxyManagerTest/Signature/SignatureCheckerTest.php
@@ -45,13 +45,13 @@ class SignatureCheckerTest extends TestCase
             ->expects(self::atLeastOnce())
             ->method('generateSignatureKey')
             ->with(['foo' => 'bar'])
-            ->will(self::returnValue('Example'));
+            ->willReturn('Example');
         $this
             ->signatureGenerator
             ->expects(self::atLeastOnce())
             ->method('generateSignature')
             ->with(['foo' => 'bar'])
-            ->will(self::returnValue('valid-signature'));
+            ->willReturn('valid-signature');
 
         $this->signatureChecker->checkSignature(new ReflectionClass($this), ['foo' => 'bar']);
     }
@@ -60,16 +60,15 @@ class SignatureCheckerTest extends TestCase
     {
         $this
             ->signatureGenerator
-            ->expects(self::any())
+
             ->method('generateSignatureKey')
             ->with(['foo' => 'bar'])
-            ->will(self::returnValue('InvalidKey'));
+            ->willReturn('InvalidKey');
         $this
             ->signatureGenerator
-            ->expects(self::any())
             ->method('generateSignature')
             ->with(['foo' => 'bar'])
-            ->will(self::returnValue('valid-signature'));
+            ->willReturn('valid-signature');
 
         $this->expectException(MissingSignatureException::class);
 
@@ -80,16 +79,14 @@ class SignatureCheckerTest extends TestCase
     {
         $this
             ->signatureGenerator
-            ->expects(self::any())
             ->method('generateSignatureKey')
             ->with(['foo' => 'bar'])
-            ->will(self::returnValue('Example'));
+            ->willReturn('Example');
         $this
             ->signatureGenerator
-            ->expects(self::any())
             ->method('generateSignature')
             ->with(['foo' => 'bar'])
-            ->will(self::returnValue('invalid-signature'));
+            ->willReturn('invalid-signature');
 
         $this->expectException(InvalidSignatureException::class);
 

--- a/tests/ProxyManagerTest/Signature/SignatureGeneratorTest.php
+++ b/tests/ProxyManagerTest/Signature/SignatureGeneratorTest.php
@@ -47,7 +47,7 @@ class SignatureGeneratorTest extends TestCase
     }
 
     /** @return string[][]|string[][][] */
-    public function signatures() : array
+    public static function signatures() : array
     {
         return [
             [
@@ -74,7 +74,7 @@ class SignatureGeneratorTest extends TestCase
     }
 
     /** @return string[][]|string[][][] */
-    public function signatureKeys() : array
+    public static function signatureKeys() : array
     {
         return [
             [[], '40cd750bba9870f18aada2478b24840a'],

--- a/tests/ProxyManagerTest/VersionTest.php
+++ b/tests/ProxyManagerTest/VersionTest.php
@@ -15,11 +15,11 @@ use ProxyManager\Version;
  */
 class VersionTest extends TestCase
 {
-    public function testGetVersion() : void
+    public static function testGetVersion() : void
     {
         $version = Version::getVersion();
 
-        self::assertInternalType('string', $version);
+        self::assertIsString($version);
         self::assertNotEmpty($version);
         self::assertStringMatchesFormat('%A@%A', $version);
     }


### PR DESCRIPTION
- Remove unnecessary assertions
- Avoid using deprecated assertions
(https://github.com/sebastianbergmann/phpunit/issues/3338)
- Add more entropy when needed
- Use static methods whenever possible (providers, test cases that don't access object context)
