### PR TITLE
#400 correcting docblock type for generated "valueHolder" properties

### DIFF
--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolderGenerator.php
@@ -64,7 +64,7 @@ class AccessInterceptorValueHolderGenerator implements ProxyGeneratorInterface
         }
 
         $classGenerator->setImplementedInterfaces($interfaces);
-        $classGenerator->addPropertyFromGenerator($valueHolder        = new ValueHolderProperty());
+        $classGenerator->addPropertyFromGenerator($valueHolder        = new ValueHolderProperty($originalClass));
         $classGenerator->addPropertyFromGenerator($prefixInterceptors = new MethodPrefixInterceptors());
         $classGenerator->addPropertyFromGenerator($suffixInterceptors = new MethodSuffixInterceptors());
         $classGenerator->addPropertyFromGenerator($publicProperties);

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/PropertyGenerator/ValueHolderProperty.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/PropertyGenerator/ValueHolderProperty.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace ProxyManager\ProxyGenerator\LazyLoadingValueHolder\PropertyGenerator;
 
 use ProxyManager\Generator\Util\IdentifierSuffixer;
+use ReflectionClass;
+use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\Exception\InvalidArgumentException;
 use Zend\Code\Generator\PropertyGenerator;
 
@@ -18,11 +20,15 @@ class ValueHolderProperty extends PropertyGenerator
      *
      * @throws InvalidArgumentException
      */
-    public function __construct()
+    public function __construct(ReflectionClass $type)
     {
         parent::__construct(IdentifierSuffixer::getIdentifier('valueHolder'));
 
+        $docBlock = new DocBlockGenerator();
+
+        $docBlock->setWordWrap(false);
+        $docBlock->setLongDescription('@var \\' . $type->getName() . '|null wrapped object, if the proxy is initialized');
+        $this->setDocBlock($docBlock);
         $this->setVisibility(self::VISIBILITY_PRIVATE);
-        $this->setDocBlock('@var \\Closure|null initializer responsible for generating the wrapped object');
     }
 }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
@@ -64,7 +64,7 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
         }
 
         $classGenerator->setImplementedInterfaces($interfaces);
-        $classGenerator->addPropertyFromGenerator($valueHolder = new ValueHolderProperty());
+        $classGenerator->addPropertyFromGenerator($valueHolder = new ValueHolderProperty($originalClass));
         $classGenerator->addPropertyFromGenerator($initializer = new InitializerProperty());
         $classGenerator->addPropertyFromGenerator($publicProperties);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/PropertyGenerator/ValueHolderPropertyTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/PropertyGenerator/ValueHolderPropertyTest.php
@@ -6,6 +6,7 @@ namespace ProxyManagerTest\ProxyGenerator\LazyLoadingValueHolder\PropertyGenerat
 
 use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\PropertyGenerator\ValueHolderProperty;
 use ProxyManagerTest\ProxyGenerator\PropertyGenerator\AbstractUniquePropertyNameTest;
+use ReflectionClass;
 use Zend\Code\Generator\PropertyGenerator;
 
 /**
@@ -21,6 +22,21 @@ class ValueHolderPropertyTest extends AbstractUniquePropertyNameTest
      */
     protected function createProperty() : PropertyGenerator
     {
-        return new ValueHolderProperty();
+        return new ValueHolderProperty(new ReflectionClass(self::class));
+    }
+
+    /** @group #400 */
+    public function testWillDocumentPropertyType() : void
+    {
+        self::assertEquals(
+            <<<'PHPDOC'
+/**
+ * @var \ProxyManagerTest\ProxyGenerator\LazyLoadingValueHolder\PropertyGenerator\ValueHolderPropertyTest|null wrapped object, if the proxy is initialized
+ */
+
+PHPDOC
+            ,
+            (new ValueHolderProperty(new ReflectionClass(self::class)))->getDocBlock()->generate()
+        );
     }
 }


### PR DESCRIPTION
Property is now correctly mapped as `OriginalType|null`

Fixes #400