### PR TITLE
Forcing latest `nikic/php-parser` releases for dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "slevomat/coding-standard":     "^4.8.7",
         "doctrine/coding-standard":     "^5.0.1",
         "couscous/couscous":            "^1.7.0",
+        "nikic/php-parser":             "^4.2.1",
         "phpbench/phpbench":            "^0.15",
         "phpstan/phpstan":              "^0.11.2",
         "phpstan/phpstan-phpunit":      "^0.11",


### PR DESCRIPTION
Without this dependency, static analysis fails due to PHP 7.2+ incompatibilities