### PR TITLE
Revert BC break - `: void` cannot be added as return type to open classes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,5 +21,8 @@
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix"/>
+
+        <!-- we cannot enforce the " : void" return type hint due to BC compliance, for now -->
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
     </rule>
 </ruleset>

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizerGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizerGenerator.php
@@ -44,8 +44,10 @@ class AccessInterceptorScopeLocalizerGenerator implements ProxyGeneratorInterfac
      *
      * @throws InvalidArgumentException
      * @throws InvalidProxiedClassException
+     *
+     * @return void
      */
-    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator) : void
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {
         CanProxyAssertion::assertClassCanBeProxied($originalClass, false);
 

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizerGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorScopeLocalizerGenerator.php
@@ -42,10 +42,10 @@ class AccessInterceptorScopeLocalizerGenerator implements ProxyGeneratorInterfac
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @throws InvalidArgumentException
      * @throws InvalidProxiedClassException
-     *
-     * @return void
      */
     public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolderGenerator.php
@@ -49,8 +49,10 @@ class AccessInterceptorValueHolderGenerator implements ProxyGeneratorInterface
      *
      * @throws InvalidArgumentException
      * @throws InvalidProxiedClassException
+     *
+     * @return void
      */
-    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator) : void
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {
         CanProxyAssertion::assertClassCanBeProxied($originalClass);
 

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolderGenerator.php
@@ -47,10 +47,10 @@ class AccessInterceptorValueHolderGenerator implements ProxyGeneratorInterface
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @throws InvalidArgumentException
      * @throws InvalidProxiedClassException
-     *
-     * @return void
      */
     public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
@@ -47,10 +47,10 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @throws InvalidProxiedClassException
      * @throws InvalidArgumentException
-     *
-     * @return void
      */
     public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator, array $proxyOptions = [])
     {

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
@@ -49,8 +49,10 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
      *
      * @throws InvalidProxiedClassException
      * @throws InvalidArgumentException
+     *
+     * @return void
      */
-    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator, array $proxyOptions = []) : void
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator, array $proxyOptions = [])
     {
         CanProxyAssertion::assertClassCanBeProxied($originalClass, false);
 

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
@@ -47,10 +47,10 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @throws InvalidProxiedClassException
      * @throws InvalidArgumentException
-     *
-     * @return void
      */
     public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
@@ -49,8 +49,10 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
      *
      * @throws InvalidProxiedClassException
      * @throws InvalidArgumentException
+     *
+     * @return void
      */
-    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator) : void
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {
         CanProxyAssertion::assertClassCanBeProxied($originalClass);
 

--- a/src/ProxyManager/ProxyGenerator/ProxyGeneratorInterface.php
+++ b/src/ProxyManager/ProxyGenerator/ProxyGeneratorInterface.php
@@ -15,6 +15,8 @@ interface ProxyGeneratorInterface
 {
     /**
      * Apply modifications to the provided $classGenerator to proxy logic from $originalClass
+     *
+     * @return void
      */
-    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator) : void;
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator);
 }

--- a/src/ProxyManager/ProxyGenerator/RemoteObjectGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObjectGenerator.php
@@ -35,10 +35,10 @@ class RemoteObjectGenerator implements ProxyGeneratorInterface
     /**
      * {@inheritDoc}
      *
+     * @return void
+     *
      * @throws InvalidProxiedClassException
      * @throws InvalidArgumentException
-     *
-     * @return void
      */
     public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {

--- a/src/ProxyManager/ProxyGenerator/RemoteObjectGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObjectGenerator.php
@@ -37,8 +37,10 @@ class RemoteObjectGenerator implements ProxyGeneratorInterface
      *
      * @throws InvalidProxiedClassException
      * @throws InvalidArgumentException
+     *
+     * @return void
      */
-    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator) : void
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
     {
         CanProxyAssertion::assertClassCanBeProxied($originalClass);
 

--- a/src/ProxyManager/Signature/SignatureCheckerInterface.php
+++ b/src/ProxyManager/Signature/SignatureCheckerInterface.php
@@ -20,6 +20,8 @@ interface SignatureCheckerInterface
      *
      * @throws InvalidSignatureException
      * @throws MissingSignatureException
+     *
+     * @return void
      */
-    public function checkSignature(ReflectionClass $class, array $parameters) : void;
+    public function checkSignature(ReflectionClass $class, array $parameters);
 }

--- a/src/ProxyManager/Signature/SignatureCheckerInterface.php
+++ b/src/ProxyManager/Signature/SignatureCheckerInterface.php
@@ -18,10 +18,10 @@ interface SignatureCheckerInterface
      *
      * @param mixed[] $parameters
      *
+     * @return void
+     *
      * @throws InvalidSignatureException
      * @throws MissingSignatureException
-     *
-     * @return void
      */
     public function checkSignature(ReflectionClass $class, array $parameters);
 }


### PR DESCRIPTION
Fixes #451 
Reverts the BC break of ` : void` being added to open classes in a minor release.