### PR TITLE
Updates FileWriterGeneratorStrategy to set permissions on the created file

### DIFF
--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -77,6 +77,7 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
         $tmpFileName = tempnam($location, 'temporaryProxyManagerFile');
 
         file_put_contents($tmpFileName, $source);
+        chmod($tmpFileName, 0666 & ~umask());
 
         if (! rename($tmpFileName, $location)) {
             unlink($tmpFileName);

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -45,6 +45,13 @@ class FileWriterGeneratorStrategyTest extends TestCase
         self::assertGreaterThan(0, strpos($body, $className));
         self::assertFalse(class_exists($fqcn, false));
         self::assertFileExists($tmpFile);
+        self::assertFileIsReadable($tmpFile);
+
+        // a user not on php.net recommended calling this as we have just called chmod on a file.
+        clearstatcache();
+
+        $perm = 0666 & ~umask();
+        self::assertTrue($perm === (fileperms($tmpFile) & 0644), 'File permission was not correct: ' . decoct($perm));
 
         /* @noinspection PhpIncludeInspection */
         require $tmpFile;


### PR DESCRIPTION
This cherry picks https://github.com/Ocramius/ProxyManager/commit/d20817ffb8712b02a8d710673c581df2c3e259a4 from master to the v2.2.x branch.

This helps us as we need the proxy files created by this library to be readable by the group and not just the owner.

Thanks!