### PR TITLE
#469 ensure factory considers `proxyOptions` when generating unique class names

### DIFF
--- a/src/ProxyManager/Factory/AbstractBaseFactory.php
+++ b/src/ProxyManager/Factory/AbstractBaseFactory.php
@@ -60,6 +60,7 @@ abstract class AbstractBaseFactory
             'className'           => $className,
             'factory'             => get_class($this),
             'proxyManagerVersion' => Version::getVersion(),
+            'proxyOptions'        => $proxyOptions,
         ];
         $proxyClassName  = $this
             ->configuration

--- a/tests/ProxyManagerTest/Factory/AbstractBaseFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AbstractBaseFactoryTest.php
@@ -17,6 +17,7 @@ use ProxyManager\Signature\SignatureCheckerInterface;
 use ReflectionMethod;
 use stdClass;
 use Zend\Code\Generator\ClassGenerator;
+use function uniqid;
 
 /**
  * Tests for {@see \ProxyManager\Factory\AbstractBaseFactory}
@@ -167,6 +168,43 @@ class AbstractBaseFactoryTest extends TestCase
         self::assertSame(
             $generatedClass,
             $generateProxy->invoke($this->factory, stdClass::class, ['some' => 'proxy', 'options' => 'here'])
+        );
+    }
+
+    /**
+     * @group 469
+     */
+    public function testGeneratesClassBasedOnGivenProxyOptions() : void
+    {
+        $generateProxy = new ReflectionMethod($this->factory, 'generateProxy');
+
+        $generateProxy->setAccessible(true);
+        $generatedClass = UniqueIdentifierGenerator::getIdentifier('fooBar');
+        $proxyOptions   = [uniqid('key', true) => uniqid('value', true)];
+
+        $this
+            ->classNameInflector
+            ->expects(self::any())
+            ->method('getProxyClassName')
+            ->with('stdClass', self::callback(static function (array $parameters) use ($proxyOptions) : bool {
+                self::assertSame($proxyOptions, $parameters['proxyOptions']);
+
+                return true;
+            }))
+            ->will(self::returnValue($generatedClass));
+
+        $this
+            ->proxyAutoloader
+            ->method('__invoke')
+            ->will(self::returnCallback(function (string $className) : bool {
+                eval('class ' . $className . ' {}');
+
+                return true;
+            }));
+
+        self::assertSame(
+            $generatedClass,
+            $generateProxy->invoke($this->factory, stdClass::class, $proxyOptions)
         );
     }
 }

--- a/tests/ProxyManagerTest/Factory/AbstractBaseFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AbstractBaseFactoryTest.php
@@ -140,7 +140,7 @@ class AbstractBaseFactoryTest extends TestCase
             ->expects(self::once())
             ->method('__invoke')
             ->with($generatedClass)
-            ->will(self::returnCallback(function ($className) : bool {
+            ->will(self::returnCallback(static function ($className) : bool {
                 eval('class ' . $className . ' {}');
 
                 return true;
@@ -153,7 +153,7 @@ class AbstractBaseFactoryTest extends TestCase
             ->expects(self::once())
             ->method('generate')
             ->with(
-                self::callback(function (\ReflectionClass $reflectionClass) : bool {
+                self::callback(static function (\ReflectionClass $reflectionClass) : bool {
                     return $reflectionClass->getName() === 'stdClass';
                 }),
                 self::isInstanceOf(ClassGenerator::class),
@@ -196,7 +196,7 @@ class AbstractBaseFactoryTest extends TestCase
         $this
             ->proxyAutoloader
             ->method('__invoke')
-            ->will(self::returnCallback(function (string $className) : bool {
+            ->will(self::returnCallback(static function (string $className) : bool {
                 eval('class ' . $className . ' {}');
 
                 return true;


### PR DESCRIPTION
Fixes #469 