### PR TITLE
Removed reliance on `Closure::bind(_, null)`

### DIFF
--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializer.php
@@ -95,7 +95,7 @@ PHP;
         foreach ($properties->getGroupedPrivateProperties() as $className => $privateProperties) {
             $cacheKey      = 'cache' . str_replace('\\', '_', $className);
             $assignments[] = 'static $' . $cacheKey . ";\n\n"
-                . '$' . $cacheKey . ' ?: $' . $cacheKey . " = \\Closure::bind(function (\$instance) {\n"
+                . '$' . $cacheKey . ' ?: $' . $cacheKey . " = \\Closure::bind(static function (\$instance) {\n"
                 . $this->getPropertyDefaultsAssignments($privateProperties) . "\n"
                 . '}, null, ' . var_export($className, true) . ");\n\n"
                 . '$' . $cacheKey . "(\$this);\n\n";

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGet.php
@@ -61,7 +61,7 @@ if (isset(self::$%s[$name])) {
         $cacheKey = $class . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function & ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function & ($instance) use ($name) {
                 return $instance->$name;
             }, null, $class);
 
@@ -73,7 +73,7 @@ if (isset(self::$%s[$name])) {
         $cacheKey = $tmpClass . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function & ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function & ($instance) use ($name) {
                 return $instance->$name;
             }, null, $tmpClass);
 

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIsset.php
@@ -56,7 +56,7 @@ if (isset(self::$%s[$name])) {
         $cacheKey = $class . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance) use ($name) {
                 return isset($instance->$name);
             }, null, $class);
 
@@ -68,7 +68,7 @@ if (isset(self::$%s[$name])) {
         $cacheKey = $tmpClass . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance) use ($name) {
                 return isset($instance->$name);
             }, null, $tmpClass);
 

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSet.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSet.php
@@ -56,7 +56,7 @@ if (isset(self::$%s[$name])) {
         $cacheKey = $class . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance, $value) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance, $value) use ($name) {
                 return ($instance->$name = $value);
             }, null, $class);
 
@@ -68,7 +68,7 @@ if (isset(self::$%s[$name])) {
         $cacheKey = $tmpClass . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance, $value) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance, $value) use ($name) {
                 return ($instance->$name = $value);
             }, null, $tmpClass);
 

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnset.php
@@ -62,7 +62,7 @@ if (isset(self::$%s[$name])) {
         $cacheKey = $class . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance) use ($name) {
                 unset($instance->$name);
             }, null, $class);
 
@@ -74,7 +74,7 @@ if (isset(self::$%s[$name])) {
         $cacheKey = $tmpClass . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance) use ($name) {
                 unset($instance->$name);
             }, null, $tmpClass);
 

--- a/src/ProxyManager/ProxyGenerator/Util/UnsetPropertiesGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/UnsetPropertiesGenerator.php
@@ -18,7 +18,7 @@ use function var_export;
 final class UnsetPropertiesGenerator
 {
     /** @var string */
-    private static $closureTemplate = <<<'PHP'
+    private const CLOSURE_TEMPLATE = <<<'PHP'
 \Closure::bind(function (\%s $instance) {
     %s
 }, $%s, %s)->__invoke($%s);
@@ -76,7 +76,7 @@ PHP;
         $declaringClassName = $declaringClass->getName();
 
         return sprintf(
-            self::$closureTemplate,
+            self::CLOSURE_TEMPLATE,
             $declaringClassName,
             self::generateUnsetStatement($properties, 'instance'),
             $instanceName,

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
@@ -35,26 +35,26 @@ final class CallInitializerTest extends TestCase
             Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedProperties::class))
         );
 
-        $expectedCode = 'if ($this->track || ! $this->init) {
+        $expectedCode = <<<'PHP'
+if ($this->track || ! $this->init) {
     return;
 }
 
 $this->track = true;
 
-$this->publicProperty0 = \'publicProperty0\';
-$this->publicProperty1 = \'publicProperty1\';
-$this->publicProperty2 = \'publicProperty2\';
-$this->protectedProperty0 = \'protectedProperty0\';
-$this->protectedProperty1 = \'protectedProperty1\';
-$this->protectedProperty2 = \'protectedProperty2\';
+$this->publicProperty0 = 'publicProperty0';
+$this->publicProperty1 = 'publicProperty1';
+$this->publicProperty2 = 'publicProperty2';
+$this->protectedProperty0 = 'protectedProperty0';
+$this->protectedProperty1 = 'protectedProperty1';
+$this->protectedProperty2 = 'protectedProperty2';
 static $cacheProxyManagerTestAsset_ClassWithMixedProperties;
 
-$cacheProxyManagerTestAsset_ClassWithMixedProperties ?: $cacheProxyManagerTestAsset_ClassWithMixedProperties = '
-        . '\Closure::bind(function ($instance) {
-    $instance->privateProperty0 = \'privateProperty0\';
-    $instance->privateProperty1 = \'privateProperty1\';
-    $instance->privateProperty2 = \'privateProperty2\';
-}, null, \'ProxyManagerTestAsset\\\\ClassWithMixedProperties\');
+$cacheProxyManagerTestAsset_ClassWithMixedProperties ?: $cacheProxyManagerTestAsset_ClassWithMixedProperties = \Closure::bind(static function ($instance) {
+    $instance->privateProperty0 = 'privateProperty0';
+    $instance->privateProperty1 = 'privateProperty1';
+    $instance->privateProperty2 = 'privateProperty2';
+}, null, 'ProxyManagerTestAsset\\ClassWithMixedProperties');
 
 $cacheProxyManagerTestAsset_ClassWithMixedProperties($this);
 
@@ -62,32 +62,29 @@ $cacheProxyManagerTestAsset_ClassWithMixedProperties($this);
 
 
 $properties = [
-    \'publicProperty0\' => & $this->publicProperty0,
-    \'publicProperty1\' => & $this->publicProperty1,
-    \'publicProperty2\' => & $this->publicProperty2,
-    \'\' . "\0" . \'*\' . "\0" . \'protectedProperty0\' => & $this->protectedProperty0,
-    \'\' . "\0" . \'*\' . "\0" . \'protectedProperty1\' => & $this->protectedProperty1,
-    \'\' . "\0" . \'*\' . "\0" . \'protectedProperty2\' => & $this->protectedProperty2,
+    'publicProperty0' => & $this->publicProperty0,
+    'publicProperty1' => & $this->publicProperty1,
+    'publicProperty2' => & $this->publicProperty2,
+    '' . "\0" . '*' . "\0" . 'protectedProperty0' => & $this->protectedProperty0,
+    '' . "\0" . '*' . "\0" . 'protectedProperty1' => & $this->protectedProperty1,
+    '' . "\0" . '*' . "\0" . 'protectedProperty2' => & $this->protectedProperty2,
 ];
 
 static $cacheFetchProxyManagerTestAsset_ClassWithMixedProperties;
 
-$cacheFetchProxyManagerTestAsset_ClassWithMixedProperties ?: $cacheFetchProxyManagerTestAsset_ClassWithMixedProperties '
-            . '= \Closure::bind(function ($instance, array & $properties) {
-    $properties[\'\' . "\0" . \'ProxyManagerTestAsset\\\\ClassWithMixedProperties\' . "\0" . \'privateProperty0\'] = '
-            . '& $instance->privateProperty0;
-    $properties[\'\' . "\0" . \'ProxyManagerTestAsset\\\\ClassWithMixedProperties\' . "\0" . \'privateProperty1\'] = '
-            . '& $instance->privateProperty1;
-    $properties[\'\' . "\0" . \'ProxyManagerTestAsset\\\\ClassWithMixedProperties\' . "\0" . \'privateProperty2\'] = '
-            . '& $instance->privateProperty2;
-}, $this, \'ProxyManagerTestAsset\\\\ClassWithMixedProperties\');
+$cacheFetchProxyManagerTestAsset_ClassWithMixedProperties ?: $cacheFetchProxyManagerTestAsset_ClassWithMixedProperties = \Closure::bind(function ($instance, array & $properties) {
+    $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedProperties' . "\0" . 'privateProperty0'] = & $instance->privateProperty0;
+    $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedProperties' . "\0" . 'privateProperty1'] = & $instance->privateProperty1;
+    $properties['' . "\0" . 'ProxyManagerTestAsset\\ClassWithMixedProperties' . "\0" . 'privateProperty2'] = & $instance->privateProperty2;
+}, $this, 'ProxyManagerTestAsset\\ClassWithMixedProperties');
 
 $cacheFetchProxyManagerTestAsset_ClassWithMixedProperties($this, $properties);
 
 $result = $this->init->__invoke($this, $methodName, $parameters, $this->init, $properties);
 $this->track = false;
 
-return $result;';
+return $result;
+PHP;
 
         self::assertSame(
             $expectedCode,
@@ -162,7 +159,7 @@ $this->protectedNullableIterableProperty = array (
 );
 static $cacheProxyManagerTestAsset_ClassWithMixedTypedProperties;
 
-$cacheProxyManagerTestAsset_ClassWithMixedTypedProperties ?: $cacheProxyManagerTestAsset_ClassWithMixedTypedProperties = \Closure::bind(function ($instance) {
+$cacheProxyManagerTestAsset_ClassWithMixedTypedProperties ?: $cacheProxyManagerTestAsset_ClassWithMixedTypedProperties = \Closure::bind(static function ($instance) {
     $instance->privateUnTypedProperty = 'privateUnTypedProperty';
     $instance->privateUnTypedPropertyWithoutDefaultValue = NULL;
     $instance->privateBoolProperty = true;

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicGetTest.php
@@ -82,7 +82,7 @@ if (isset(self::$baz[$name])) {
         $cacheKey = $class . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function & ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function & ($instance) use ($name) {
                 return $instance->$name;
             }, null, $class);
 
@@ -94,7 +94,7 @@ if (isset(self::$baz[$name])) {
         $cacheKey = $tmpClass . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function & ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function & ($instance) use ($name) {
                 return $instance->$name;
             }, null, $tmpClass);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicIssetTest.php
@@ -73,7 +73,7 @@ if (isset(self::$baz[$name])) {
         $cacheKey = $class . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance) use ($name) {
                 return isset($instance->$name);
             }, null, $class);
 
@@ -85,7 +85,7 @@ if (isset(self::$baz[$name])) {
         $cacheKey = $tmpClass . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance) use ($name) {
                 return isset($instance->$name);
             }, null, $tmpClass);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSetTest.php
@@ -73,7 +73,7 @@ if (isset(self::$baz[$name])) {
         $cacheKey = $class . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance, $value) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance, $value) use ($name) {
                 return ($instance->$name = $value);
             }, null, $class);
 
@@ -85,7 +85,7 @@ if (isset(self::$baz[$name])) {
         $cacheKey = $tmpClass . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance, $value) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance, $value) use ($name) {
                 return ($instance->$name = $value);
             }, null, $tmpClass);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicUnsetTest.php
@@ -79,7 +79,7 @@ if (isset(self::$baz[$name])) {
         $cacheKey = $class . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance) use ($name) {
                 unset($instance->$name);
             }, null, $class);
 
@@ -91,7 +91,7 @@ if (isset(self::$baz[$name])) {
         $cacheKey = $tmpClass . '#' . $name;
         $accessor = isset($accessorCache[$cacheKey])
             ? $accessorCache[$cacheKey]
-            : $accessorCache[$cacheKey] = \Closure::bind(function ($instance) use ($name) {
+            : $accessorCache[$cacheKey] = \Closure::bind(static function ($instance) use ($name) {
                 unset($instance->$name);
             }, null, $tmpClass);
 


### PR DESCRIPTION
`Closure::bind()` without a `$this` is deprecated since https://wiki.php.net/rfc/deprecations_php_7_4#unbinding_this_from_non-static_closures,
and therefore we remove reliance on it, or use `static` closures instead.