### PR TITLE
Fix deprecation PHP 7.4

### DIFF
--- a/src/ProxyManager/Generator/Util/ProxiedMethodReturnExpression.php
+++ b/src/ProxyManager/Generator/Util/ProxiedMethodReturnExpression.php
@@ -16,7 +16,15 @@ final class ProxiedMethodReturnExpression
 {
     public static function generate(string $returnedValueExpression, ?\ReflectionMethod $originalMethod) : string
     {
-        if ($originalMethod && 'void' === (string) $originalMethod->getReturnType()) {
+        $originalReturnType = $originalMethod === null
+            ? null
+            : $originalMethod->getReturnType();
+
+        $originalReturnTypeName = $originalReturnType === null
+            ? null
+            : $originalReturnType->getName();
+
+        if ($originalReturnTypeName === 'void') {
             return $returnedValueExpression . ";\nreturn;";
         }
 


### PR DESCRIPTION
This PR fixes a deprecation notice that is triggered when the package is used on PHP 7.4.
I'd prefer having this patch on 2.1, but it's not maintained anymore, right? Looks like 2.2 is?
Patch borrowed from #467 so this should reduce merge/cherry-pick conflicts.
Thanks for considering!