### PR TITLE
Remove process isolation from tests around file writer generators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "ext-phar":                     "*",
-        "phpunit/phpunit":              "^8.2.2",
+        "phpunit/phpunit":              "^8.2.2,<8.3.0",
         "squizlabs/php_codesniffer":    "^3.4.2",
         "slevomat/coding-standard":     "^5.0.4",
         "doctrine/coding-standard":     "^6.0.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "ext-phar":                     "*",
-        "phpunit/phpunit":              "^8.2.2,<8.3.0",
+        "phpunit/phpunit":              "^8.2.2",
         "squizlabs/php_codesniffer":    "^3.4.2",
         "slevomat/coding-standard":     "^5.0.4",
         "doctrine/coding-standard":     "^6.0.0",

--- a/src/ProxyManager/Generator/Util/UniqueIdentifierGenerator.php
+++ b/src/ProxyManager/Generator/Util/UniqueIdentifierGenerator.php
@@ -21,7 +21,6 @@ abstract class UniqueIdentifierGenerator
      * Generates a valid unique identifier from the given name
      *
      * @psalm-return class-string
-     *
      * @psalm-suppress MoreSpecificReturnType
      */
     public static function getIdentifier(string $name) : string

--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -45,10 +45,9 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
      */
     public function generate(ClassGenerator $classGenerator) : string
     {
-        $className = $classGenerator->getNamespaceName()
-            . '\\' . trim($classGenerator->getName(), '\\');
         /** @var string $generatedCode */
         $generatedCode = $classGenerator->generate();
+        $className     = $classGenerator->getNamespaceName() . '\\' . $classGenerator->getName();
         $fileName      = $this->fileLocator->getProxyFileName($className);
 
         set_error_handler($this->emptyErrorHandler);

--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -45,7 +45,7 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
      */
     public function generate(ClassGenerator $classGenerator) : string
     {
-        $className = trim($classGenerator->getNamespaceName(), '\\')
+        $className = $classGenerator->getNamespaceName()
             . '\\' . trim($classGenerator->getName(), '\\');
         /** @var string $generatedCode */
         $generatedCode = $classGenerator->generate();

--- a/src/ProxyManager/ProxyGenerator/Util/Properties.php
+++ b/src/ProxyManager/ProxyGenerator/Util/Properties.php
@@ -102,6 +102,8 @@ final class Properties
 
     /**
      * Properties that cannot be referenced are non-nullable typed properties that aren't initialised
+     *
+     * @deprecated no longer in use: please do not rely on this method
      */
     public function withoutNonReferenceableProperties() : self
     {

--- a/src/ProxyManager/ProxyGenerator/Util/Properties.php
+++ b/src/ProxyManager/ProxyGenerator/Util/Properties.php
@@ -102,8 +102,6 @@ final class Properties
 
     /**
      * Properties that cannot be referenced are non-nullable typed properties that aren't initialised
-     *
-     * @deprecated no longer in use: please do not rely on this method
      */
     public function withoutNonReferenceableProperties() : self
     {

--- a/src/ProxyManager/ProxyGenerator/Util/UnsetPropertiesGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/UnsetPropertiesGenerator.php
@@ -17,7 +17,6 @@ use function var_export;
  */
 final class UnsetPropertiesGenerator
 {
-    /** @var string */
     private const CLOSURE_TEMPLATE = <<<'PHP'
 \Closure::bind(function (\%s $instance) {
     %s

--- a/tests/ProxyManagerTest/Factory/AccessInterceptorValueHolderFactoryTest.php
+++ b/tests/ProxyManagerTest/Factory/AccessInterceptorValueHolderFactoryTest.php
@@ -186,7 +186,7 @@ final class AccessInterceptorValueHolderFactoryTest extends TestCase
                 self::fail('Not supposed to be called');
             },
         ];
-        $proxy = $factory->createProxy($instance, $prefixInterceptors, $suffixInterceptors);
+        $proxy              = $factory->createProxy($instance, $prefixInterceptors, $suffixInterceptors);
 
         self::assertInstanceOf($proxyClassName, $proxy);
         self::assertSame($instance, $proxy->instance);

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorScopeLocalizerFunctionalTest.php
@@ -26,6 +26,7 @@ use ProxyManagerTestAsset\VoidCounter;
 use ReflectionClass;
 use stdClass;
 use function array_values;
+use function get_class;
 use function random_int;
 use function serialize;
 use function uniqid;
@@ -268,8 +269,8 @@ final class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
      */
     public function testCanWriteToArrayKeysInPublicProperty() : void
     {
-        $instance  = new ClassWithPublicArrayPropertyAccessibleViaMethod();
-        $proxy     = (new AccessInterceptorScopeLocalizerFactory())->createProxy($instance);
+        $instance = new ClassWithPublicArrayPropertyAccessibleViaMethod();
+        $proxy    = (new AccessInterceptorScopeLocalizerFactory())->createProxy($instance);
 
         $proxy->arrayProperty['foo'] = 'bar';
 
@@ -287,8 +288,8 @@ final class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
      */
     public function testWillNotModifyRetrievedPublicProperties() : void
     {
-        $instance  = new ClassWithPublicProperties();
-        $proxy     = (new AccessInterceptorScopeLocalizerFactory())->createProxy($instance);
+        $instance = new ClassWithPublicProperties();
+        $proxy    = (new AccessInterceptorScopeLocalizerFactory())->createProxy($instance);
 
         $variable = $proxy->property0;
 
@@ -308,8 +309,8 @@ final class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
      */
     public function testWillModifyByRefRetrievedPublicProperties() : void
     {
-        $instance  = new ClassWithPublicProperties();
-        $proxy     = (new AccessInterceptorScopeLocalizerFactory())->createProxy($instance);
+        $instance = new ClassWithPublicProperties();
+        $proxy    = (new AccessInterceptorScopeLocalizerFactory())->createProxy($instance);
 
         $variable = &$proxy->property0;
 
@@ -403,7 +404,7 @@ final class AccessInterceptorScopeLocalizerFunctionalTest extends TestCase
      */
     public function getPropertyAccessProxies() : array
     {
-        $instance  = new BaseClass();
+        $instance = new BaseClass();
 
         return [
             [

--- a/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/AccessInterceptorValueHolderFunctionalTest.php
@@ -273,8 +273,8 @@ final class AccessInterceptorValueHolderFunctionalTest extends TestCase
      */
     public function testCanWriteToArrayKeysInPublicProperty() : void
     {
-        $instance  = new ClassWithPublicArrayPropertyAccessibleViaMethod();
-        $proxy     = (new AccessInterceptorValueHolderFactory())->createProxy($instance);
+        $instance = new ClassWithPublicArrayPropertyAccessibleViaMethod();
+        $proxy    = (new AccessInterceptorValueHolderFactory())->createProxy($instance);
 
         $proxy->arrayProperty['foo'] = 'bar';
 
@@ -290,7 +290,7 @@ final class AccessInterceptorValueHolderFunctionalTest extends TestCase
      */
     public function testWillNotModifyRetrievedPublicProperties() : void
     {
-        $instance  = new ClassWithPublicProperties();
+        $instance = new ClassWithPublicProperties();
         $proxy    = (new AccessInterceptorValueHolderFactory())->createProxy($instance);
         $variable = $proxy->property0;
 
@@ -307,7 +307,7 @@ final class AccessInterceptorValueHolderFunctionalTest extends TestCase
      */
     public function testWillModifyByRefRetrievedPublicProperties() : void
     {
-        $instance  = new ClassWithPublicProperties();
+        $instance = new ClassWithPublicProperties();
         $proxy    = (new AccessInterceptorValueHolderFactory())->createProxy($instance);
         $variable = &$proxy->property0;
 
@@ -468,8 +468,8 @@ final class AccessInterceptorValueHolderFunctionalTest extends TestCase
      */
     public function getPropertyAccessProxies() : array
     {
-        $instance1  = new BaseClass();
-        $instance2  = new BaseClass();
+        $instance1 = new BaseClass();
+        $instance2 = new BaseClass();
         /** @var AccessInterceptorValueHolderInterface $serialized */
         $serialized = unserialize(serialize((new AccessInterceptorValueHolderFactory())->createProxy($instance2)));
 

--- a/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/FatalPreventionFunctionalTest.php
@@ -50,8 +50,8 @@ final class FatalPreventionFunctionalTest extends TestCase
      */
     public function testCodeGeneration(string $generatorClass, string $className) : void
     {
-        $generatedClass    = new ClassGenerator(uniqid('generated', true));
-        $generatorStrategy = new EvaluatingGeneratorStrategy();
+        $generatedClass          = new ClassGenerator(uniqid('generated', true));
+        $generatorStrategy       = new EvaluatingGeneratorStrategy();
         $classGenerator          = new $generatorClass();
         $classSignatureGenerator = new ClassSignatureGenerator(new SignatureGenerator());
 

--- a/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingGhostFunctionalTest.php
@@ -169,7 +169,7 @@ final class LazyLoadingGhostFunctionalTest extends TestCase
         array $params,
         $expectedValue
     ) : void {
-        $proxy = (new LazyLoadingGhostFactory())->createProxy(
+        $proxy  = (new LazyLoadingGhostFactory())->createProxy(
             $className,
             $this->createInitializer($className, $instance)
         );
@@ -438,7 +438,7 @@ final class LazyLoadingGhostFunctionalTest extends TestCase
                 ?Closure & $initializer,
                 array $properties
             ) : bool {
-                $initializer                                                                            = null;
+                $initializer                                                                                              = null;
                 $properties["\0" . ClassWithCollidingPrivateInheritedProperties::class . "\0property0"]                   = 'foo';
                 $properties["\0" . get_parent_class(ClassWithCollidingPrivateInheritedProperties::class) . "\0property0"] = 'bar';
 
@@ -820,7 +820,6 @@ final class LazyLoadingGhostFunctionalTest extends TestCase
 
     /**
      * @psalm-param (CallableInterface&Mock)|null $initializerMatcher
-     *
      * @psalm-return Closure(
      *   GhostObjectInterface $proxy,
      *   string $method,
@@ -990,8 +989,8 @@ final class LazyLoadingGhostFunctionalTest extends TestCase
      */
     public function getPropertyAccessProxies() : array
     {
-        $instance1  = new BaseClass();
-        $instance2  = new BaseClass();
+        $instance1 = new BaseClass();
+        $instance2 = new BaseClass();
 
         $factory = new LazyLoadingGhostFactory();
 
@@ -1219,7 +1218,10 @@ final class LazyLoadingGhostFunctionalTest extends TestCase
                 array $params,
                 ?Closure & $initializer,
                 array $properties
-            ) use ($propertyIndex, $expectedValue) : bool {
+            ) use (
+                $propertyIndex,
+                $expectedValue
+            ) : bool {
                 $initializer = null;
 
                 $properties[$propertyIndex] = $expectedValue;
@@ -1251,20 +1253,24 @@ final class LazyLoadingGhostFunctionalTest extends TestCase
         $proxy = unserialize(serialize(
             (new LazyLoadingGhostFactory())->createProxy(
                 OtherObjectAccessClass::class,
-            static function (
-                GhostObjectInterface$proxy,
-                string $method,
-                array $params,
-                ?Closure & $initializer,
-                array $properties
-            ) use ($propertyIndex, $expectedValue) : bool {
-                $initializer = null;
+                static function (
+                    GhostObjectInterface $proxy,
+                    string $method,
+                    array $params,
+                    ?Closure & $initializer,
+                    array $properties
+                ) use (
+                    $propertyIndex,
+                    $expectedValue
+                ) : bool {
+                    $initializer = null;
 
-                $properties[$propertyIndex] = $expectedValue;
+                    $properties[$propertyIndex] = $expectedValue;
 
-                return true;
-            }
-        )));
+                    return true;
+                }
+            )
+        ));
 
         $accessor = [$callerObject, $method];
 
@@ -1292,7 +1298,10 @@ final class LazyLoadingGhostFunctionalTest extends TestCase
                 array $params,
                 ?Closure & $initializer,
                 array $properties
-            ) use ($propertyIndex, $expectedValue) : bool {
+            ) use (
+                $propertyIndex,
+                $expectedValue
+            ) : bool {
                 $initializer = null;
 
                 $properties[$propertyIndex] = $expectedValue;

--- a/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
@@ -125,7 +125,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
         array $params,
         $expectedValue
     ) : void {
-        $proxy = (new LazyLoadingValueHolderFactory())->createProxy(
+        $proxy  = (new LazyLoadingValueHolderFactory())->createProxy(
             $className,
             $this->createInitializer($className, $instance)
         );
@@ -236,7 +236,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
      */
     public function testWillNotModifyRetrievedPublicProperties() : void
     {
-        $proxy = (new LazyLoadingValueHolderFactory())->createProxy(
+        $proxy    = (new LazyLoadingValueHolderFactory())->createProxy(
             ClassWithPublicProperties::class,
             $this->createInitializer(ClassWithPublicProperties::class, new ClassWithPublicProperties())
         );
@@ -255,7 +255,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
      */
     public function testWillModifyByRefRetrievedPublicProperties() : void
     {
-        $proxy = (new LazyLoadingValueHolderFactory())->createProxy(
+        $proxy    = (new LazyLoadingValueHolderFactory())->createProxy(
             ClassWithPublicProperties::class,
             $this->createInitializer(ClassWithPublicProperties::class, new ClassWithPublicProperties())
         );
@@ -276,7 +276,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
      */
     public function testWillAllowMultipleProxyInitialization() : void
     {
-        $counter    = 0;
+        $counter = 0;
 
         $proxy = (new LazyLoadingValueHolderFactory())->createProxy(
             BaseClass::class,
@@ -375,8 +375,6 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
     }
 
     /**
-     * @psalm-param (CallableInterface&Mock)|null $initializerMatcher
-     *
      * @return Closure(
      *  object|null,
      *  VirtualProxyInterface,
@@ -384,6 +382,8 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
      *  array,
      *  ?Closure
      * ) : bool
+     *
+     * @psalm-param (CallableInterface&Mock)|null $initializerMatcher
      */
     private function createInitializer(string $className, object $realInstance, ?Mock $initializerMatcher = null) : Closure
     {
@@ -534,9 +534,9 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
      */
     public function getPropertyAccessProxies() : array
     {
-        $instance1  = new BaseClass();
-        $instance2  = new BaseClass();
-        $factory    = new LazyLoadingValueHolderFactory();
+        $instance1 = new BaseClass();
+        $instance2 = new BaseClass();
+        $factory   = new LazyLoadingValueHolderFactory();
         /** @var VirtualProxyInterface $serialized */
         $serialized = unserialize(serialize($factory->createProxy(
             BaseClass::class,
@@ -598,7 +598,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
     ) : void {
         $className = get_class($realInstance);
         /** @var LazyLoadingInterface $proxy */
-        $proxy     = unserialize(serialize((new LazyLoadingValueHolderFactory())->createProxy(
+        $proxy = unserialize(serialize((new LazyLoadingValueHolderFactory())->createProxy(
             $className,
             $this->createInitializer($className, $realInstance)
         )));

--- a/tests/ProxyManagerTest/Generator/Util/ClassGeneratorUtilsTest.php
+++ b/tests/ProxyManagerTest/Generator/Util/ClassGeneratorUtilsTest.php
@@ -23,7 +23,7 @@ final class ClassGeneratorUtilsTest extends TestCase
 {
     public function testCantAddAFinalMethod() : void
     {
-        $classGenerator = $this->createMock(ClassGenerator::class);
+        $classGenerator  = $this->createMock(ClassGenerator::class);
         $methodGenerator = $this->createMock(MethodGenerator::class);
 
         $methodGenerator
@@ -42,7 +42,7 @@ final class ClassGeneratorUtilsTest extends TestCase
 
     public function testCanAddANotFinalMethod() : void
     {
-        $classGenerator = $this->createMock(ClassGenerator::class);
+        $classGenerator  = $this->createMock(ClassGenerator::class);
         $methodGenerator = $this->createMock(MethodGenerator::class);
 
         $methodGenerator

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\GeneratorStrategy;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Exception\FileNotWritableException;
 use ProxyManager\FileLocator\FileLocatorInterface;
@@ -17,6 +16,7 @@ use function class_exists;
 use function clearstatcache;
 use function decoct;
 use function fileperms;
+use function ini_get;
 use function ini_set;
 use function is_dir;
 use function mkdir;
@@ -24,15 +24,15 @@ use function rmdir;
 use function scandir;
 use function strpos;
 use function sys_get_temp_dir;
+use function tempnam;
 use function umask;
 use function uniqid;
 
 /**
  * Tests for {@see \ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy}
  *
- * @group Coverage
+ * @group  Coverage
  * @covers \ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy
- * @runTestsInSeparateProcesses
  *
  * Note: this test generates temporary files that are not deleted
  */
@@ -42,13 +42,12 @@ final class FileWriterGeneratorStrategyTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->tempDir = sys_get_temp_dir() . '/' . uniqid('FileWriterGeneratorStrategyTest', true);
+        parent::setUp();
 
-        if (! is_dir($this->tempDir)) {
-            mkdir($this->tempDir);
-        }
+        $this->tempDir = tempnam(sys_get_temp_dir(), 'FileWriterGeneratorStrategyTest');
 
-        ini_set('open_basedir', __DIR__ . '/../../..' . PATH_SEPARATOR . $this->tempDir);
+        unlink($this->tempDir);
+        mkdir($this->tempDir);
     }
 
     public function testGenerate() : void

--- a/tests/ProxyManagerTest/ProxyGenerator/AbstractProxyGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AbstractProxyGeneratorTest.php
@@ -36,7 +36,6 @@ abstract class AbstractProxyGeneratorTest extends TestCase
      * @dataProvider getTestedImplementations
      *
      * Verifies that generated code is valid and implements expected interfaces
-     *
      * @psalm-param class-string $className
      */
     public function testGeneratesValidCode(string $className) : void

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicCloneTest.php
@@ -24,7 +24,7 @@ final class MagicCloneTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -43,7 +43,7 @@ final class MagicCloneTest extends TestCase
      */
     public function testBodyStructureWithInheritedMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
+        $reflection         = new ReflectionClass(ClassWithMagicMethods::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicGetTest.php
@@ -24,7 +24,7 @@ final class MagicGetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -47,7 +47,7 @@ final class MagicGetTest extends TestCase
      */
     public function testBodyStructureWithInheritedMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
+        $reflection         = new ReflectionClass(ClassWithMagicMethods::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicIssetTest.php
@@ -24,7 +24,7 @@ final class MagicIssetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -47,7 +47,7 @@ final class MagicIssetTest extends TestCase
      */
     public function testBodyStructureWithInheritedMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
+        $reflection         = new ReflectionClass(ClassWithMagicMethods::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSetTest.php
@@ -24,7 +24,7 @@ final class MagicSetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -47,7 +47,7 @@ final class MagicSetTest extends TestCase
      */
     public function testBodyStructureWithInheritedMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
+        $reflection         = new ReflectionClass(ClassWithMagicMethods::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicSleepTest.php
@@ -24,7 +24,7 @@ final class MagicSleepTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -47,7 +47,7 @@ final class MagicSleepTest extends TestCase
      */
     public function testBodyStructureWithInheritedMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
+        $reflection         = new ReflectionClass(ClassWithMagicMethods::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnsetTest.php
@@ -24,7 +24,7 @@ final class MagicUnsetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -47,7 +47,7 @@ final class MagicUnsetTest extends TestCase
      */
     public function testBodyStructureWithInheritedMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
+        $reflection         = new ReflectionClass(ClassWithMagicMethods::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/Util/InterceptorGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/Util/InterceptorGeneratorTest.php
@@ -24,9 +24,9 @@ final class InterceptorGeneratorTest extends TestCase
 {
     public function testInterceptorGenerator() : void
     {
-        $method = $this->createMock(MethodGenerator::class);
-        $bar = $this->createMock(ParameterGenerator::class);
-        $baz = $this->createMock(ParameterGenerator::class);
+        $method             = $this->createMock(MethodGenerator::class);
+        $bar                = $this->createMock(ParameterGenerator::class);
+        $baz                = $this->createMock(ParameterGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -77,9 +77,9 @@ PHP;
 
     public function testInterceptorGeneratorWithVoidReturnType() : void
     {
-        $method = $this->createMock(MethodGenerator::class);
-        $bar = $this->createMock(ParameterGenerator::class);
-        $baz = $this->createMock(ParameterGenerator::class);
+        $method             = $this->createMock(MethodGenerator::class);
+        $bar                = $this->createMock(ParameterGenerator::class);
+        $baz                = $this->createMock(ParameterGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -133,9 +133,9 @@ PHP;
 
     public function testInterceptorGeneratorWithExistingNonVoidMethod() : void
     {
-        $method = $this->createMock(MethodGenerator::class);
-        $bar = $this->createMock(ParameterGenerator::class);
-        $baz = $this->createMock(ParameterGenerator::class);
+        $method             = $this->createMock(MethodGenerator::class);
+        $bar                = $this->createMock(ParameterGenerator::class);
+        $baz                = $this->createMock(ParameterGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/InterceptedMethodTest.php
@@ -23,7 +23,7 @@ final class InterceptedMethodTest extends TestCase
 {
     public function testBodyStructure() : void
     {
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicCloneTest.php
@@ -23,8 +23,8 @@ final class MagicCloneTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGetTest.php
@@ -24,11 +24,11 @@ final class MagicGetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
-        $publicProperties = $this->createMock(PublicPropertiesMap::class);
+        $publicProperties   = $this->createMock(PublicPropertiesMap::class);
 
         $valueHolder->method('getName')->willReturn('bar');
         $prefixInterceptors->method('getName')->willReturn('pre');

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIssetTest.php
@@ -25,11 +25,11 @@ final class MagicIssetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
-        $publicProperties = $this->createMock(PublicPropertiesMap::class);
+        $publicProperties   = $this->createMock(PublicPropertiesMap::class);
 
         $valueHolder->method('getName')->willReturn('bar');
         $prefixInterceptors->method('getName')->willReturn('pre');

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicSetTest.php
@@ -25,11 +25,11 @@ final class MagicSetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
-        $publicProperties = $this->createMock(PublicPropertiesMap::class);
+        $publicProperties   = $this->createMock(PublicPropertiesMap::class);
 
         $valueHolder->method('getName')->willReturn('bar');
         $prefixInterceptors->method('getName')->willReturn('pre');

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnsetTest.php
@@ -25,11 +25,11 @@ final class MagicUnsetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection         = new ReflectionClass(EmptyClass::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
-        $publicProperties = $this->createMock(PublicPropertiesMap::class);
+        $publicProperties   = $this->createMock(PublicPropertiesMap::class);
 
         $valueHolder->method('getName')->willReturn('bar');
         $prefixInterceptors->method('getName')->willReturn('pre');

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/StaticProxyConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/StaticProxyConstructorTest.php
@@ -23,7 +23,7 @@ final class StaticProxyConstructorTest extends TestCase
 {
     public function testBodyStructure() : void
     {
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -63,7 +63,7 @@ return $instance;',
 
     public function testBodyStructureWithoutPublicProperties() : void
     {
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -98,7 +98,7 @@ return $instance;',
      */
     public function testUnsetsPrivatePropertiesAsWell() : void
     {
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/Util/InterceptorGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/Util/InterceptorGeneratorTest.php
@@ -24,10 +24,10 @@ final class InterceptorGeneratorTest extends TestCase
 {
     public function testInterceptorGenerator() : void
     {
-        $method = $this->createMock(MethodGenerator::class);
-        $bar = $this->createMock(ParameterGenerator::class);
-        $baz = $this->createMock(ParameterGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $method             = $this->createMock(MethodGenerator::class);
+        $bar                = $this->createMock(ParameterGenerator::class);
+        $baz                = $this->createMock(ParameterGenerator::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -80,10 +80,10 @@ PHP;
 
     public function testInterceptorGeneratorWithVoidMethod() : void
     {
-        $method = $this->createMock(MethodGenerator::class);
-        $bar = $this->createMock(ParameterGenerator::class);
-        $baz = $this->createMock(ParameterGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $method             = $this->createMock(MethodGenerator::class);
+        $bar                = $this->createMock(ParameterGenerator::class);
+        $baz                = $this->createMock(ParameterGenerator::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 
@@ -139,10 +139,10 @@ PHP;
 
     public function testInterceptorGeneratorWithNonVoidOriginalMethod() : void
     {
-        $method = $this->createMock(MethodGenerator::class);
-        $bar = $this->createMock(ParameterGenerator::class);
-        $baz = $this->createMock(ParameterGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $method             = $this->createMock(MethodGenerator::class);
+        $bar                = $this->createMock(ParameterGenerator::class);
+        $baz                = $this->createMock(ParameterGenerator::class);
+        $valueHolder        = $this->createMock(PropertyGenerator::class);
         $prefixInterceptors = $this->createMock(PropertyGenerator::class);
         $suffixInterceptors = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/Assertion/CanProxyAssertionTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Assertion/CanProxyAssertionTest.php
@@ -75,7 +75,6 @@ final class CanProxyAssertionTest extends TestCase
 
     /**
      * @dataProvider validClasses
-     *
      * @psalm-param class-string $className
      */
     public function testAllowedClass(string $className) : void

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/CallInitializerTest.php
@@ -23,7 +23,7 @@ final class CallInitializerTest extends TestCase
 {
     public function testBodyStructure() : void
     {
-        $initializer = $this->createMock(PropertyGenerator::class);
+        $initializer           = $this->createMock(PropertyGenerator::class);
         $initializationTracker = $this->createMock(PropertyGenerator::class);
 
         $initializer->method('getName')->willReturn('init');
@@ -94,7 +94,7 @@ PHP;
 
     public function testBodyStructureWithTypedProperties() : void
     {
-        $initializer = $this->createMock(PropertyGenerator::class);
+        $initializer           = $this->createMock(PropertyGenerator::class);
         $initializationTracker = $this->createMock(PropertyGenerator::class);
 
         $initializer->method('getName')->willReturn('init');

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/InitializeProxyTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/InitializeProxyTest.php
@@ -23,7 +23,7 @@ final class InitializeProxyTest extends TestCase
     public function testBodyStructure() : void
     {
         $initializer = $this->createMock(PropertyGenerator::class);
-        $initCall = $this->createMock(MethodGenerator::class);
+        $initCall    = $this->createMock(MethodGenerator::class);
 
         $initializer->method('getName')->willReturn('foo');
         $initCall->method('getName')->willReturn('bar');

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicCloneTest.php
@@ -24,9 +24,9 @@ final class MagicCloneTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection  = new ReflectionClass(EmptyClass::class);
         $initializer = $this->createMock(PropertyGenerator::class);
-        $initCall = $this->createMock(MethodGenerator::class);
+        $initCall    = $this->createMock(MethodGenerator::class);
 
         $initializer->method('getName')->willReturn('foo');
         $initCall->method('getName')->willReturn('bar');

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingGhost/MethodGenerator/MagicSleepTest.php
@@ -24,9 +24,9 @@ final class MagicSleepTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection  = new ReflectionClass(EmptyClass::class);
         $initializer = $this->createMock(PropertyGenerator::class);
-        $initMethod = $this->createMock(MethodGenerator::class);
+        $initMethod  = $this->createMock(MethodGenerator::class);
 
         $initializer->method('getName')->willReturn('foo');
         $initMethod->method('getName')->willReturn('bar');

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/LazyLoadingMethodInterceptorTest.php
@@ -48,8 +48,8 @@ final class LazyLoadingMethodInterceptorTest extends TestCase
     public function testBodyStructureWithoutParameters() : void
     {
         $reflectionMethod = new MethodReflection(BaseClass::class, 'publicMethod');
-        $initializer = $this->createMock(PropertyGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $initializer      = $this->createMock(PropertyGenerator::class);
+        $valueHolder      = $this->createMock(PropertyGenerator::class);
 
         $initializer->method('getName')->willReturn('foo');
         $valueHolder->method('getName')->willReturn('bar');

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicCloneTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicCloneTest.php
@@ -23,7 +23,7 @@ final class MagicCloneTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection  = new ReflectionClass(EmptyClass::class);
         $initializer = $this->createMock(PropertyGenerator::class);
         $valueHolder = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicGetTest.php
@@ -25,9 +25,9 @@ final class MagicGetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $initializer = $this->createMock(PropertyGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection       = new ReflectionClass(EmptyClass::class);
+        $initializer      = $this->createMock(PropertyGenerator::class);
+        $valueHolder      = $this->createMock(PropertyGenerator::class);
         $publicProperties = $this->createMock(PublicPropertiesMap::class);
 
         $initializer->method('getName')->willReturn('foo');
@@ -54,9 +54,9 @@ final class MagicGetTest extends TestCase
      */
     public function testBodyStructureWithPreExistingGetMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
-        $initializer = $this->createMock(PropertyGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection       = new ReflectionClass(ClassWithMagicMethods::class);
+        $initializer      = $this->createMock(PropertyGenerator::class);
+        $valueHolder      = $this->createMock(PropertyGenerator::class);
         $publicProperties = $this->createMock(PublicPropertiesMap::class);
 
         $initializer->method('getName')->willReturn('foo');

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicIssetTest.php
@@ -24,9 +24,9 @@ final class MagicIssetTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $initializer = $this->createMock(PropertyGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection       = new ReflectionClass(EmptyClass::class);
+        $initializer      = $this->createMock(PropertyGenerator::class);
+        $valueHolder      = $this->createMock(PropertyGenerator::class);
         $publicProperties = $this->createMock(PublicPropertiesMap::class);
 
         $initializer->method('getName')->willReturn('foo');

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSetTest.php
@@ -23,9 +23,9 @@ final class MagicSetTest extends TestCase
 {
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $initializer = $this->createMock(PropertyGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection       = new ReflectionClass(EmptyClass::class);
+        $initializer      = $this->createMock(PropertyGenerator::class);
+        $valueHolder      = $this->createMock(PropertyGenerator::class);
         $publicProperties = $this->createMock(PublicPropertiesMap::class);
 
         $initializer->method('getName')->willReturn('foo');
@@ -51,9 +51,9 @@ final class MagicSetTest extends TestCase
      */
     public function testBodyStructureWithPreExistingMagicMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
-        $initializer = $this->createMock(PropertyGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection       = new ReflectionClass(ClassWithMagicMethods::class);
+        $initializer      = $this->createMock(PropertyGenerator::class);
+        $valueHolder      = $this->createMock(PropertyGenerator::class);
         $publicProperties = $this->createMock(PublicPropertiesMap::class);
 
         $initializer->method('getName')->willReturn('foo');

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicSleepTest.php
@@ -23,7 +23,7 @@ final class MagicSleepTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection  = new ReflectionClass(EmptyClass::class);
         $initializer = $this->createMock(PropertyGenerator::class);
         $valueHolder = $this->createMock(PropertyGenerator::class);
 

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnsetTest.php
@@ -23,9 +23,9 @@ final class MagicUnsetTest extends TestCase
 {
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
-        $initializer = $this->createMock(PropertyGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection       = new ReflectionClass(EmptyClass::class);
+        $initializer      = $this->createMock(PropertyGenerator::class);
+        $valueHolder      = $this->createMock(PropertyGenerator::class);
         $publicProperties = $this->createMock(PublicPropertiesMap::class);
 
         $initializer->method('getName')->willReturn('foo');
@@ -51,9 +51,9 @@ final class MagicUnsetTest extends TestCase
      */
     public function testBodyStructureWithPreExistingMagicMethod() : void
     {
-        $reflection = new ReflectionClass(ClassWithMagicMethods::class);
-        $initializer = $this->createMock(PropertyGenerator::class);
-        $valueHolder = $this->createMock(PropertyGenerator::class);
+        $reflection       = new ReflectionClass(ClassWithMagicMethods::class);
+        $initializer      = $this->createMock(PropertyGenerator::class);
+        $valueHolder      = $this->createMock(PropertyGenerator::class);
         $publicProperties = $this->createMock(PublicPropertiesMap::class);
 
         $initializer->method('getName')->willReturn('foo');

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicGetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicGetTest.php
@@ -24,7 +24,7 @@ final class MagicGetTest extends TestCase
     public function testBodyStructure() : void
     {
         $reflection = new ReflectionClass(EmptyClass::class);
-        $adapter = $this->createMock(PropertyGenerator::class);
+        $adapter    = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('foo');
 
         $magicGet = new MagicGet($reflection, $adapter);

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicIssetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicIssetTest.php
@@ -24,7 +24,7 @@ final class MagicIssetTest extends TestCase
     public function testBodyStructure() : void
     {
         $reflection = new ReflectionClass(EmptyClass::class);
-        $adapter = $this->createMock(PropertyGenerator::class);
+        $adapter    = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('foo');
 
         $magicGet = new MagicIsset($reflection, $adapter);

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicSetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicSetTest.php
@@ -24,7 +24,7 @@ final class MagicSetTest extends TestCase
     public function testBodyStructure() : void
     {
         $reflection = new ReflectionClass(EmptyClass::class);
-        $adapter = $this->createMock(PropertyGenerator::class);
+        $adapter    = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('foo');
 
         $magicGet = new MagicSet($reflection, $adapter);

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/MagicUnsetTest.php
@@ -24,7 +24,7 @@ final class MagicUnsetTest extends TestCase
     public function testBodyStructure() : void
     {
         $reflection = new ReflectionClass(EmptyClass::class);
-        $adapter = $this->createMock(PropertyGenerator::class);
+        $adapter    = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('foo');
 
         $magicGet = new MagicUnset($reflection, $adapter);

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PropertiesTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PropertiesTest.php
@@ -15,6 +15,7 @@ use ProxyManagerTestAsset\ClassWithMixedTypedProperties;
 use ProxyManagerTestAsset\ClassWithPrivateProperties;
 use ReflectionClass;
 use ReflectionProperty;
+use function array_keys;
 use function array_map;
 use function array_values;
 
@@ -422,7 +423,7 @@ final class PropertiesTest extends TestCase
         ];
     }
 
-    public function testWithoutNonReferenceableProperties()
+    public function testWithoutNonReferenceableProperties() : void
     {
         $properties = Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedTypedProperties::class))
             ->withoutNonReferenceableProperties()

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PropertiesTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PropertiesTest.php
@@ -421,4 +421,39 @@ final class PropertiesTest extends TestCase
             ["\0ProxyManagerTestAsset\\ClassWithMixedProperties\0privateProperty0"],
         ];
     }
+
+    public function testWithoutNonReferenceableProperties()
+    {
+        $properties = Properties::fromReflectionClass(new ReflectionClass(ClassWithMixedTypedProperties::class))
+            ->withoutNonReferenceableProperties()
+            ->getPublicProperties();
+
+        self::assertSame(
+            [
+                'publicUnTypedProperty',
+                'publicUnTypedPropertyWithoutDefaultValue',
+                'publicBoolProperty',
+                'publicNullableBoolProperty',
+                'publicNullableBoolPropertyWithoutDefaultValue',
+                'publicIntProperty',
+                'publicNullableIntProperty',
+                'publicNullableIntPropertyWithoutDefaultValue',
+                'publicFloatProperty',
+                'publicNullableFloatProperty',
+                'publicNullableFloatPropertyWithoutDefaultValue',
+                'publicStringProperty',
+                'publicNullableStringProperty',
+                'publicNullableStringPropertyWithoutDefaultValue',
+                'publicArrayProperty',
+                'publicNullableArrayProperty',
+                'publicNullableArrayPropertyWithoutDefaultValue',
+                'publicIterableProperty',
+                'publicNullableIterableProperty',
+                'publicNullableIterablePropertyWithoutDefaultValue',
+                'publicNullableObjectProperty',
+                'publicNullableClassProperty',
+            ],
+            array_keys($properties)
+        );
+    }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/UnsetPropertiesGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/UnsetPropertiesGeneratorTest.php
@@ -24,7 +24,6 @@ final class UnsetPropertiesGeneratorTest extends TestCase
 {
     /**
      * @dataProvider classNamesProvider
-     *
      * @psalm-param class-string $className
      */
     public function testGeneratedCode(string $className, string $expectedCode, string $instanceName) : void

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/MagicSleepTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/MagicSleepTest.php
@@ -23,7 +23,7 @@ final class MagicSleepTest extends TestCase
      */
     public function testBodyStructure() : void
     {
-        $reflection = new ReflectionClass(EmptyClass::class);
+        $reflection  = new ReflectionClass(EmptyClass::class);
         $valueHolder = $this->createMock(PropertyGenerator::class);
 
         $valueHolder->method('getName')->willReturn('bar');


### PR DESCRIPTION
See https://github.com/sebastianbergmann/phpunit/issues/3772

~~As discussed with @sebastianbergmann, PHPUnit 8.3.4 may fix this issue, but until then,
we lock onto an older version to have green builds to validate a release~~

For now, we simply remove process isolation to simplify the issue overall