### PR TITLE
RemoteObjectMethod generation: support for methods with default parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "psr-4": {
             "ProxyManagerBench\\": "tests/ProxyManagerBench",
             "ProxyManagerTest\\": "tests/ProxyManagerTest",
-            "ProxyManagerTestAsset\\": "tests/ProxyManagerTestAsset"
+            "ProxyManagerTestAsset\\": "tests/ProxyManagerTestAsset",
+            "Zend": "tests/Stubbed/Zend"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
             "ProxyManagerBench\\": "tests/ProxyManagerBench",
             "ProxyManagerTest\\": "tests/ProxyManagerTest",
             "ProxyManagerTestAsset\\": "tests/ProxyManagerTestAsset",
-            "Zend": "tests/Stubbed/Zend"
+            "Zend\\": "tests/Stubbed/Zend"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
             "ProxyManagerBench\\": "tests/ProxyManagerBench",
             "ProxyManagerTest\\": "tests/ProxyManagerTest",
             "ProxyManagerTestAsset\\": "tests/ProxyManagerTestAsset",
-            "Zend\\": "tests/Stubbed/Zend"
+            "Zend\\Server\\": "tests/Stubbed/Zend/Server"
         }
     },
     "extra": {

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
@@ -68,6 +68,7 @@ PHP;
         $defaultValues = [];
         foreach ($originalMethod->getParameters() as $parameter) {
             if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {
+                /** @psalm-var int|float|bool|array|string|null */
                 $defaultValues[] = $parameter->getDefaultValue();
                 continue;
             }

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
@@ -44,17 +44,15 @@ PHP;
         $defaultValues          = self::getDefaultValuesForMethod($originalMethod);
         $declaredParameterCount = count($originalMethod->getParameters());
 
-        $body = strtr(
-            self::TEMPLATE,
-            [
-                '#PROXIED_RETURN#' => $proxiedReturn,
-                '#DEFAULT_VALUES#' => var_export($defaultValues, true),
-                '#PARAMETER_COUNT#' => var_export($declaredParameterCount, true),
-            ]
-        );
-
         $method->setBody(
-            $body
+            strtr(
+                self::TEMPLATE,
+                [
+                    '#PROXIED_RETURN#' => $proxiedReturn,
+                    '#DEFAULT_VALUES#' => var_export($defaultValues, true),
+                    '#PARAMETER_COUNT#' => var_export($declaredParameterCount, true),
+                ]
+            )
         );
 
         return $method;

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
@@ -9,8 +9,8 @@ use ProxyManager\Generator\Util\ProxiedMethodReturnExpression;
 use ReflectionClass;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Reflection\MethodReflection;
-
-use function str_replace;
+use function count;
+use function strtr;
 use function var_export;
 
 /**
@@ -18,21 +18,14 @@ use function var_export;
  */
 class RemoteObjectMethod extends MethodGenerator
 {
-    /** @var string */
     private const TEMPLATE
-        = <<<PHP
-\$reflectionMethod = new \\ReflectionMethod(__CLASS__, __FUNCTION__);
-\$args = \\func_get_args();
-foreach (\\array_slice(\$reflectionMethod->getParameters(), \\count(\$args)) as \$param) {
-            /**
-             * @var ReflectionParameter \$param
-             */
-            if (\$param->isDefaultValueAvailable()) {
-                \$args[] = \$param->getDefaultValue();
-            }
-}
+        = <<<'PHP'
+$defaultValues = #DEFAULT_VALUES#;
+$declaredParameterCount = #PARAMETER_COUNT#;
 
-#proxiedReturn#
+$args = \func_get_args() + $defaultValues;
+
+#PROXIED_RETURN#
 PHP;
 
     /** @return self|static */
@@ -40,18 +33,36 @@ PHP;
         MethodReflection $originalMethod,
         PropertyGenerator $adapterProperty,
         ReflectionClass $originalClass
-    ): self {
+    ) : self {
+        $defaultValues = [];
+        foreach ($originalMethod->getParameters() as $parameter) {
+            if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {
+                $defaultValues[] = $parameter->getDefaultValue();
+                continue;
+            }
+
+            if ($parameter->isVariadic()) {
+                continue;
+            }
+
+            $defaultValues[] = null;
+        }
+        $declaredParameterCount = count($originalMethod->getParameters());
+
         /** @var self $method */
-        $method = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
+        $method        = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $proxiedReturn = '$return = $this->' . $adapterProperty->getName()
             . '->call(' . var_export($originalClass->getName(), true)
             . ', ' . var_export($originalMethod->getName(), true) . ', $args);' . "\n\n"
             . ProxiedMethodReturnExpression::generate('$return', $originalMethod);
 
-        $body = str_replace(
-            ['#proxiedReturn#'],
-            ['#proxciedReturn#' => $proxiedReturn],
+        $body = strtr(
             self::TEMPLATE,
+            [
+                '#PROXIED_RETURN#' => $proxiedReturn,
+                '#DEFAULT_VALUES#' => var_export($defaultValues, true),
+                '#PARAMETER_COUNT#' => var_export($declaredParameterCount, true),
+            ]
         );
 
         $method->setBody(

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
@@ -9,6 +9,8 @@ use ProxyManager\Generator\Util\ProxiedMethodReturnExpression;
 use ReflectionClass;
 use Zend\Code\Generator\PropertyGenerator;
 use Zend\Code\Reflection\MethodReflection;
+
+use function str_replace;
 use function var_export;
 
 /**
@@ -16,20 +18,44 @@ use function var_export;
  */
 class RemoteObjectMethod extends MethodGenerator
 {
+    /** @var string */
+    private const TEMPLATE
+        = <<<PHP
+\$reflectionMethod = new \\ReflectionMethod(__CLASS__, __FUNCTION__);
+\$args = \\func_get_args();
+foreach (\\array_slice(\$reflectionMethod->getParameters(), \\count(\$args)) as \$param) {
+            /**
+             * @var ReflectionParameter \$param
+             */
+            if (\$param->isDefaultValueAvailable()) {
+                \$args[] = \$param->getDefaultValue();
+            }
+}
+
+#proxiedReturn#
+PHP;
+
     /** @return self|static */
     public static function generateMethod(
         MethodReflection $originalMethod,
         PropertyGenerator $adapterProperty,
         ReflectionClass $originalClass
-    ) : self {
+    ): self {
         /** @var self $method */
         $method = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
+        $proxiedReturn = '$return = $this->' . $adapterProperty->getName()
+            . '->call(' . var_export($originalClass->getName(), true)
+            . ', ' . var_export($originalMethod->getName(), true) . ', $args);' . "\n\n"
+            . ProxiedMethodReturnExpression::generate('$return', $originalMethod);
+
+        $body = str_replace(
+            ['#proxiedReturn#'],
+            ['#proxciedReturn#' => $proxiedReturn],
+            self::TEMPLATE,
+        );
 
         $method->setBody(
-            '$return = $this->' . $adapterProperty->getName()
-            . '->call(' . var_export($originalClass->getName(), true)
-            . ', ' . var_export($originalMethod->getName(), true) . ', \func_get_args());' . "\n\n"
-            . ProxiedMethodReturnExpression::generate('$return', $originalMethod)
+            $body
         );
 
         return $method;

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
@@ -41,7 +41,7 @@ PHP;
             . ', ' . var_export($originalMethod->getName(), true) . ', $args);' . "\n\n"
             . ProxiedMethodReturnExpression::generate('$return', $originalMethod);
 
-        $defaultValues = self::getDefaultValuesForMethod($originalMethod)
+        $defaultValues          = self::getDefaultValuesForMethod($originalMethod);
         $declaredParameterCount = count($originalMethod->getParameters());
 
         $body = strtr(
@@ -61,10 +61,9 @@ PHP;
     }
 
     /**
-     * @param MethodReflection $originalMethod
      * @return array
      */
-    private static function getDefaultValuesForMethod(MethodReflection $originalMethod): array
+    private static function getDefaultValuesForMethod(MethodReflection $originalMethod) : array
     {
         $defaultValues = [];
         foreach ($originalMethod->getParameters() as $parameter) {

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -15,6 +15,7 @@ use ProxyManagerTestAsset\OtherObjectAccessClass;
 use ProxyManagerTestAsset\RemoteProxy\BazServiceInterface;
 use ProxyManagerTestAsset\RemoteProxy\Foo;
 use ProxyManagerTestAsset\RemoteProxy\FooServiceInterface;
+use ProxyManagerTestAsset\RemoteProxy\RemoteServiceWithDefaultsAndVariadicArguments;
 use ProxyManagerTestAsset\RemoteProxy\RemoteServiceWithDefaultsInterface;
 use ProxyManagerTestAsset\RemoteProxy\VariadicArgumentsServiceInterface;
 use ProxyManagerTestAsset\VoidCounter;
@@ -206,6 +207,70 @@ final class RemoteObjectFunctionalTest extends TestCase
                 'optionalNullable',
                 ['aaa'],
                 ['aaa', null],
+                200,
+            ],
+            'when passing only the required parameters' => [
+                RemoteServiceWithDefaultsInterface::class,
+                'manyRequiredWithManyOptional',
+                ['aaa', 100],
+                [
+                    'aaa',
+                    100,
+                    'Optional parameter to be kept during calls',
+                    100,
+                    'Yet another optional parameter to be kept during calls',
+                ],
+                200,
+            ],
+            'when passing required params and one optional params' => [
+                RemoteServiceWithDefaultsInterface::class,
+                'manyRequiredWithManyOptional',
+                ['aaa', 100, 'passed'],
+                [
+                    'aaa',
+                    100,
+                    'passed',
+                    100,
+                    'Yet another optional parameter to be kept during calls',
+                ],
+                200,
+            ],
+            'when passing required params and some optional params' => [
+                RemoteServiceWithDefaultsInterface::class,
+                'manyRequiredWithManyOptional',
+                ['aaa', 100, 'passed', 90],
+                [
+                    'aaa',
+                    100,
+                    'passed',
+                    90,
+                    'Yet another optional parameter to be kept during calls',
+                ],
+                200,
+            ],
+            'when passing only required for method with optional and variadic params' => [
+                RemoteServiceWithDefaultsAndVariadicArguments::class,
+                'optionalWithVariadic',
+                ['aaa'],
+                [
+                    'aaa',
+                    'Optional param to be kept on proxy call',
+                ],
+                200,
+            ],
+            'when passing required, optional and variadic params' => [
+                RemoteServiceWithDefaultsAndVariadicArguments::class,
+                'optionalWithVariadic',
+                ['aaa', 'Optional param to be kept on proxy call', 10, 20, 30, 50, 90],
+                [
+                    'aaa',
+                    'Optional param to be kept on proxy call',
+                    10,
+                    20,
+                    30,
+                    50,
+                    90,
+                ],
                 200,
             ],
         ];

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -139,7 +139,7 @@ final class RemoteObjectFunctionalTest extends TestCase
         $proxy = (new RemoteObjectFactory($this->getJsonRpcAdapter($propertyValue, '__get', [$publicProperty])))
             ->createProxy($instanceOrClassName);
 
-        self::assertSame($propertyValue, $proxy->{$publicProperty});
+        self::assertSame($propertyValue, $proxy->$publicProperty);
     }
 
     /**

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -40,7 +40,6 @@ final class RemoteObjectFunctionalTest extends TestCase
      */
     protected function getXmlRpcAdapter($expectedValue, string $method, array $params) : XmlRpcAdapter
     {
-        /** @var Client|MockObject $client */
         $client = $this->getMockBuilder(Client::class)->getMock();
 
         $client
@@ -60,7 +59,6 @@ final class RemoteObjectFunctionalTest extends TestCase
      */
     protected function getJsonRpcAdapter($expectedValue, string $method, array $params) : JsonRpcAdapter
     {
-        /** @var Client|MockObject $client */
         $client = $this->getMockBuilder(Client::class)->getMock();
 
         $client

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -36,15 +36,15 @@ final class RemoteObjectFunctionalTest extends TestCase
 {
     /**
      * @param mixed   $expectedValue
-     * @param mixed[] $params
+     * @param mixed[] $parametersExpectedByClient
      */
-    protected function getXmlRpcAdapter($expectedValue, string $method, array $params) : XmlRpcAdapter
+    protected function getXmlRpcAdapter($expectedValue, string $method, array $parametersExpectedByClient) : XmlRpcAdapter
     {
         $client = $this->getMockBuilder(Client::class)->getMock();
 
         $client
             ->method('call')
-            ->with(self::stringEndsWith($method), $params)
+            ->with(self::stringEndsWith($method), $parametersExpectedByClient)
             ->willReturn($expectedValue);
 
         return new XmlRpcAdapter(
@@ -75,7 +75,7 @@ final class RemoteObjectFunctionalTest extends TestCase
     /**
      * @param string|object $instanceOrClassName
      * @param array|mixed[] $passedParams
-     * @param mixed[]       $parametersForProxy
+     * @param mixed[]       $callParametersExpectedByAdapter
      * @param mixed         $expectedValue
      *
      * @dataProvider getProxyMethods
@@ -87,10 +87,10 @@ final class RemoteObjectFunctionalTest extends TestCase
         $instanceOrClassName,
         string $method,
         array $passedParams,
-        array $parametersForProxy,
+        array $callParametersExpectedByAdapter,
         $expectedValue
     ) : void {
-        $proxy = (new RemoteObjectFactory($this->getXmlRpcAdapter($expectedValue, $method, $parametersForProxy)))
+        $proxy = (new RemoteObjectFactory($this->getXmlRpcAdapter($expectedValue, $method, $callParametersExpectedByAdapter)))
             ->createProxy($instanceOrClassName);
 
         $callback = [$proxy, $method];

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -21,7 +21,6 @@ use ProxyManagerTestAsset\RemoteProxy\VariadicArgumentsServiceInterface;
 use ProxyManagerTestAsset\VoidCounter;
 use ReflectionClass;
 use Zend\Server\Client;
-
 use function get_class;
 use function random_int;
 use function ucfirst;
@@ -36,12 +35,10 @@ use function uniqid;
 final class RemoteObjectFunctionalTest extends TestCase
 {
     /**
-     * @param mixed $expectedValue
-     * @param string $method
+     * @param mixed   $expectedValue
      * @param mixed[] $params
-     * @return XmlRpcAdapter
      */
-    protected function getXmlRpcAdapter($expectedValue, string $method, array $params): XmlRpcAdapter
+    protected function getXmlRpcAdapter($expectedValue, string $method, array $params) : XmlRpcAdapter
     {
         /** @var Client|MockObject $client */
         $client = $this->getMockBuilder(Client::class)->getMock();
@@ -58,12 +55,10 @@ final class RemoteObjectFunctionalTest extends TestCase
     }
 
     /**
-     * @param mixed $expectedValue
-     * @param string $method
+     * @param mixed   $expectedValue
      * @param mixed[] $params
-     * @return JsonRpcAdapter
      */
-    protected function getJsonRpcAdapter($expectedValue, string $method, array $params): JsonRpcAdapter
+    protected function getJsonRpcAdapter($expectedValue, string $method, array $params) : JsonRpcAdapter
     {
         /** @var Client|MockObject $client */
         $client = $this->getMockBuilder(Client::class)->getMock();
@@ -81,10 +76,9 @@ final class RemoteObjectFunctionalTest extends TestCase
 
     /**
      * @param string|object $instanceOrClassName
-     * @param string $method
-     * @param array $passedParams
-     * @param mixed[] $parametersForProxy
-     * @param mixed $expectedValue
+     * @param array|mixed[] $passedParams
+     * @param mixed[]       $parametersForProxy
+     * @param mixed         $expectedValue
      *
      * @dataProvider getProxyMethods
      *
@@ -97,7 +91,7 @@ final class RemoteObjectFunctionalTest extends TestCase
         array $passedParams,
         array $parametersForProxy,
         $expectedValue
-    ): void {
+    ) : void {
         $proxy = (new RemoteObjectFactory($this->getXmlRpcAdapter($expectedValue, $method, $parametersForProxy)))
             ->createProxy($instanceOrClassName);
 
@@ -109,10 +103,9 @@ final class RemoteObjectFunctionalTest extends TestCase
 
     /**
      * @param string|object $instanceOrClassName
-     * @param string $method
-     * @param array $passedParams
-     * @param mixed[] $parametersForProxy
-     * @param mixed $expectedValue
+     * @param array|mixed[] $passedParams
+     * @param mixed[]       $parametersForProxy
+     * @param mixed         $expectedValue
      *
      * @dataProvider getProxyMethods
      *
@@ -125,7 +118,7 @@ final class RemoteObjectFunctionalTest extends TestCase
         array $passedParams,
         array $parametersForProxy,
         $expectedValue
-    ): void {
+    ) : void {
         $proxy = (new RemoteObjectFactory($this->getJsonRpcAdapter($expectedValue, $method, $parametersForProxy)))
             ->createProxy($instanceOrClassName);
 
@@ -137,15 +130,14 @@ final class RemoteObjectFunctionalTest extends TestCase
 
     /**
      * @param string|object $instanceOrClassName
-     * @param string $publicProperty
-     * @param mixed $propertyValue
+     * @param mixed         $propertyValue
      *
      * @dataProvider getPropertyAccessProxies
      *
      * @psalm-template OriginalClass of object
      * @psalm-param class-string<OriginalClass>|OriginalClass $instanceOrClassName
      */
-    public function testJsonRpcPropertyReadAccess($instanceOrClassName, string $publicProperty, $propertyValue): void
+    public function testJsonRpcPropertyReadAccess($instanceOrClassName, string $publicProperty, $propertyValue) : void
     {
         $proxy = (new RemoteObjectFactory($this->getJsonRpcAdapter($propertyValue, '__get', [$publicProperty])))
             ->createProxy($instanceOrClassName);
@@ -158,7 +150,7 @@ final class RemoteObjectFunctionalTest extends TestCase
      *
      * @return string[][]|bool[][]|object[][]|mixed[][][]
      */
-    public function getProxyMethods(): array
+    public function getProxyMethods() : array
     {
         $selfHintParam = new ClassWithSelfHint();
 
@@ -210,15 +202,15 @@ final class RemoteObjectFunctionalTest extends TestCase
                 'optionalNonNullable',
                 ['aaa'],
                 ['aaa', ''],
-                200
+                200,
             ],
             [
                 RemoteServiceWithDefaultsInterface::class,
                 'optionalNullable',
                 ['aaa'],
                 ['aaa', null],
-                200
-            ]
+                200,
+            ],
         ];
     }
 
@@ -227,7 +219,7 @@ final class RemoteObjectFunctionalTest extends TestCase
      *
      * @return string[][]
      */
-    public function getPropertyAccessProxies(): array
+    public function getPropertyAccessProxies() : array
     {
         return [
             [
@@ -241,12 +233,6 @@ final class RemoteObjectFunctionalTest extends TestCase
     /**
      * @group        276
      * @dataProvider getMethodsThatAccessPropertiesOnOtherObjectsInTheSameScope
-     *
-     * @param object $callerObject
-     * @param object $realInstance
-     * @param string $method
-     * @param string $expectedValue
-     * @param string $propertyName
      */
     public function testWillInterceptAccessToPropertiesViaFriendClassAccess(
         object $callerObject,
@@ -254,7 +240,7 @@ final class RemoteObjectFunctionalTest extends TestCase
         string $method,
         string $expectedValue,
         string $propertyName
-    ): void {
+    ) : void {
         $adapter = $this->createMock(AdapterInterface::class);
 
         $adapter
@@ -275,12 +261,6 @@ final class RemoteObjectFunctionalTest extends TestCase
     /**
      * @group        276
      * @dataProvider getMethodsThatAccessPropertiesOnOtherObjectsInTheSameScope
-     *
-     * @param object $callerObject
-     * @param object $realInstance
-     * @param string $method
-     * @param string $expectedValue
-     * @param string $propertyName
      */
     public function testWillInterceptAccessToPropertiesViaFriendClassAccessEvenIfCloned(
         object $callerObject,
@@ -288,7 +268,7 @@ final class RemoteObjectFunctionalTest extends TestCase
         string $method,
         string $expectedValue,
         string $propertyName
-    ): void {
+    ) : void {
         $adapter = $this->createMock(AdapterInterface::class);
 
         $adapter
@@ -309,7 +289,7 @@ final class RemoteObjectFunctionalTest extends TestCase
     /**
      * @group 327
      */
-    public function testWillExecuteLogicInAVoidMethod(): void
+    public function testWillExecuteLogicInAVoidMethod() : void
     {
         $adapter = $this->createMock(AdapterInterface::class);
 
@@ -327,16 +307,13 @@ final class RemoteObjectFunctionalTest extends TestCase
         $proxy->increment($increment);
     }
 
-    /**
-     * @return Generator
-     */
-    public function getMethodsThatAccessPropertiesOnOtherObjectsInTheSameScope(): Generator
+    public function getMethodsThatAccessPropertiesOnOtherObjectsInTheSameScope() : Generator
     {
         foreach ((new ReflectionClass(OtherObjectAccessClass::class))->getProperties() as $property) {
             $property->setAccessible(true);
 
-            $propertyName = $property->getName();
-            $realInstance = new OtherObjectAccessClass();
+            $propertyName  = $property->getName();
+            $realInstance  = new OtherObjectAccessClass();
             $expectedValue = uniqid('', true);
 
             $property->setValue($realInstance, $expectedValue);

--- a/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/RemoteObjectFunctionalTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ProxyManagerTest\Functional;
 
 use Generator;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Factory\RemoteObject\Adapter\JsonRpc as JsonRpcAdapter;
 use ProxyManager\Factory\RemoteObject\Adapter\XmlRpc as XmlRpcAdapter;
@@ -199,7 +198,7 @@ final class RemoteObjectFunctionalTest extends TestCase
                 RemoteServiceWithDefaultsInterface::class,
                 'optionalNonNullable',
                 ['aaa'],
-                ['aaa', ''],
+                ['aaa', 'Optional parameter to be kept during calls'],
                 200,
             ],
             [

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\ProxyGenerator\RemoteObject\MethodGenerator;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\ProxyGenerator\RemoteObject\MethodGenerator\RemoteObjectMethod;
 use ProxyManagerTestAsset\BaseClass;
@@ -20,9 +19,29 @@ use Zend\Code\Reflection\MethodReflection;
 final class RemoteObjectMethodTest extends TestCase
 {
     /**
+     * @var string
+     */
+    private const STATIC_CODE = <<<PHP
+\$reflectionMethod = new \\ReflectionMethod(__CLASS__, __FUNCTION__);
+\$args = \\func_get_args();
+foreach (\\array_slice(\$reflectionMethod->getParameters(), \\count(\$args)) as \$param) {
+            /**
+             * @var ReflectionParameter \$param
+             */
+            if (\$param->isDefaultValueAvailable()) {
+                \$args[] = \$param->getDefaultValue();
+            }
+}
+
+
+PHP;
+
+
+
+    /**
      * @covers \ProxyManager\ProxyGenerator\RemoteObject\MethodGenerator\RemoteObjectMethod
      */
-    public function testBodyStructureWithParameters() : void
+    public function testBodyStructureWithParameters(): void
     {
         $adapter = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('adapter');
@@ -41,8 +60,8 @@ final class RemoteObjectMethodTest extends TestCase
         self::assertSame('publicByReferenceParameterMethod', $method->getName());
         self::assertCount(2, $method->getParameters());
         self::assertSame(
-            '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
-            . '\'publicByReferenceParameterMethod\', \func_get_args());'
+            self::STATIC_CODE . '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
+            . '\'publicByReferenceParameterMethod\', $args);'
             . "\n\nreturn \$return;",
             $method->getBody()
         );
@@ -51,7 +70,7 @@ final class RemoteObjectMethodTest extends TestCase
     /**
      * @covers \ProxyManager\ProxyGenerator\RemoteObject\MethodGenerator\RemoteObjectMethod
      */
-    public function testBodyStructureWithArrayParameter() : void
+    public function testBodyStructureWithArrayParameter(): void
     {
         $adapter = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('adapter');
@@ -67,8 +86,8 @@ final class RemoteObjectMethodTest extends TestCase
         self::assertSame('publicArrayHintedMethod', $method->getName());
         self::assertCount(1, $method->getParameters());
         self::assertSame(
-            '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
-            . '\'publicArrayHintedMethod\', \func_get_args());'
+            self::STATIC_CODE . '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
+            . '\'publicArrayHintedMethod\', $args);'
             . "\n\nreturn \$return;",
             $method->getBody()
         );
@@ -77,7 +96,7 @@ final class RemoteObjectMethodTest extends TestCase
     /**
      * @covers \ProxyManager\ProxyGenerator\RemoteObject\MethodGenerator\RemoteObjectMethod
      */
-    public function testBodyStructureWithoutParameters() : void
+    public function testBodyStructureWithoutParameters(): void
     {
         $adapter = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('adapter');
@@ -93,8 +112,8 @@ final class RemoteObjectMethodTest extends TestCase
         self::assertSame('publicMethod', $method->getName());
         self::assertCount(0, $method->getParameters());
         self::assertSame(
-            '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
-            . '\'publicMethod\', \func_get_args());'
+            self::STATIC_CODE . '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
+            . '\'publicMethod\', $args);'
             . "\n\nreturn \$return;",
             $method->getBody()
         );

--- a/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethodTest.php
@@ -19,29 +19,9 @@ use Zend\Code\Reflection\MethodReflection;
 final class RemoteObjectMethodTest extends TestCase
 {
     /**
-     * @var string
-     */
-    private const STATIC_CODE = <<<PHP
-\$reflectionMethod = new \\ReflectionMethod(__CLASS__, __FUNCTION__);
-\$args = \\func_get_args();
-foreach (\\array_slice(\$reflectionMethod->getParameters(), \\count(\$args)) as \$param) {
-            /**
-             * @var ReflectionParameter \$param
-             */
-            if (\$param->isDefaultValueAvailable()) {
-                \$args[] = \$param->getDefaultValue();
-            }
-}
-
-
-PHP;
-
-
-
-    /**
      * @covers \ProxyManager\ProxyGenerator\RemoteObject\MethodGenerator\RemoteObjectMethod
      */
-    public function testBodyStructureWithParameters(): void
+    public function testBodyStructureWithParameters() : void
     {
         $adapter = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('adapter');
@@ -60,9 +40,17 @@ PHP;
         self::assertSame('publicByReferenceParameterMethod', $method->getName());
         self::assertCount(2, $method->getParameters());
         self::assertSame(
-            self::STATIC_CODE . '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
-            . '\'publicByReferenceParameterMethod\', $args);'
-            . "\n\nreturn \$return;",
+            '$defaultValues = array (
+  0 => NULL,
+  1 => NULL,
+);
+$declaredParameterCount = 2;
+
+$args = \func_get_args() + $defaultValues;
+
+$return = $this->adapter->call(\'Zend\\\\Code\\\\Generator\\\\PropertyGenerator\', \'publicByReferenceParameterMethod\', $args);
+
+return $return;',
             $method->getBody()
         );
     }
@@ -70,7 +58,7 @@ PHP;
     /**
      * @covers \ProxyManager\ProxyGenerator\RemoteObject\MethodGenerator\RemoteObjectMethod
      */
-    public function testBodyStructureWithArrayParameter(): void
+    public function testBodyStructureWithArrayParameter() : void
     {
         $adapter = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('adapter');
@@ -86,9 +74,16 @@ PHP;
         self::assertSame('publicArrayHintedMethod', $method->getName());
         self::assertCount(1, $method->getParameters());
         self::assertSame(
-            self::STATIC_CODE . '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
-            . '\'publicArrayHintedMethod\', $args);'
-            . "\n\nreturn \$return;",
+            "\$defaultValues = array (
+  0 => NULL,
+);
+\$declaredParameterCount = 1;
+
+\$args = \\func_get_args() + \$defaultValues;
+
+\$return = \$this->adapter->call('Zend\\\\Code\\\\Generator\\\\PropertyGenerator', 'publicArrayHintedMethod', \$args);
+
+return \$return;",
             $method->getBody()
         );
     }
@@ -96,7 +91,7 @@ PHP;
     /**
      * @covers \ProxyManager\ProxyGenerator\RemoteObject\MethodGenerator\RemoteObjectMethod
      */
-    public function testBodyStructureWithoutParameters(): void
+    public function testBodyStructureWithoutParameters() : void
     {
         $adapter = $this->createMock(PropertyGenerator::class);
         $adapter->method('getName')->willReturn('adapter');
@@ -112,9 +107,15 @@ PHP;
         self::assertSame('publicMethod', $method->getName());
         self::assertCount(0, $method->getParameters());
         self::assertSame(
-            self::STATIC_CODE . '$return = $this->adapter->call(\'Zend\\\Code\\\Generator\\\PropertyGenerator\', '
-            . '\'publicMethod\', $args);'
-            . "\n\nreturn \$return;",
+            "\$defaultValues = array (
+);
+\$declaredParameterCount = 0;
+
+\$args = \\func_get_args() + \$defaultValues;
+
+\$return = \$this->adapter->call('Zend\\\\Code\\\\Generator\\\\PropertyGenerator', 'publicMethod', \$args);
+
+return \$return;",
             $method->getBody()
         );
     }

--- a/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsAndVariadicArguments.php
+++ b/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsAndVariadicArguments.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * CRM PROJECT
+ * THIS FILE IS A PART OF CRM PROJECT
+ * CRM PROJECT IS PROPERTY OF Legal One GmbH
+ */
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset\RemoteProxy;
+
+interface RemoteServiceWithDefaultsAndVariadicArguments
+{
+    public function optionalWithVariadic(
+        string $required,
+        string $optional = 'Optional param to be kept on proxy call',
+        int ...$ints
+    );
+}

--- a/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsInterface.php
+++ b/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsInterface.php
@@ -6,13 +6,10 @@ namespace ProxyManagerTestAsset\RemoteProxy;
 
 /**
  * Simple interface for a remote API that methods with default parameters
- *
- * @author Pedro Tanaka <pedro.stanaka@gmail.com>
- * @license MIT
  */
 interface RemoteServiceWithDefaultsInterface
 {
-    public function optionalNonNullable(string $foo, string $optional = ''): int;
+    public function optionalNonNullable(string $foo, string $optional = '') : int;
 
-    public function optionalNullable(string $foo, ?float $nullable = null): int;
+    public function optionalNullable(string $foo, ?float $nullable = null) : int;
 }

--- a/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsInterface.php
+++ b/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset\RemoteProxy;
+
+/**
+ * Simple interface for a remote API that methods with default parameters
+ *
+ * @author Pedro Tanaka <pedro.stanaka@gmail.com>
+ * @license MIT
+ */
+interface RemoteServiceWithDefaultsInterface
+{
+    public function optionalNonNullable(string $foo, string $optional = ''): int;
+
+    public function optionalNullable(string $foo, ?float $nullable = null): int;
+}

--- a/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsInterface.php
+++ b/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsInterface.php
@@ -11,5 +11,13 @@ interface RemoteServiceWithDefaultsInterface
 {
     public function optionalNonNullable(string $foo, string $optional = 'Optional parameter to be kept during calls') : int;
 
+    public function manyRequiredWithManyOptional(
+        string $required,
+        int $requiredInt,
+        string $optional = 'Optional parameter to be kept during calls',
+        int $optionalInt = 100,
+        string $optionalStr = 'Yet another optional parameter to be kept during calls'
+    );
+
     public function optionalNullable(string $foo, ?float $nullable = null) : int;
 }

--- a/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsInterface.php
+++ b/tests/ProxyManagerTestAsset/RemoteProxy/RemoteServiceWithDefaultsInterface.php
@@ -9,7 +9,7 @@ namespace ProxyManagerTestAsset\RemoteProxy;
  */
 interface RemoteServiceWithDefaultsInterface
 {
-    public function optionalNonNullable(string $foo, string $optional = '') : int;
+    public function optionalNonNullable(string $foo, string $optional = 'Optional parameter to be kept during calls') : int;
 
     public function optionalNullable(string $foo, ?float $nullable = null) : int;
 }

--- a/tests/Stubbed/Zend/Server/Client.php
+++ b/tests/Stubbed/Zend/Server/Client.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @see       https://github.com/zendframework/zend-server for the canonical source repository
+ */
+
+namespace Zend\Server;
+
+/**
+ * Client Interface
+ */
+interface Client
+{
+    /**
+     * Executes remote call
+     *
+     * Unified interface for calling custom remote methods.
+     *
+     * @param  string        $method Remote call name.
+     * @param  array|mixed[] $params Call parameters.
+     *
+     * @return mixed Remote call results.
+     */
+    public function call(string $method, array $params = []);
+}

--- a/tests/language-feature-scripts/remote-object-json-adapter-default-parameters-and-variadic.phpt
+++ b/tests/language-feature-scripts/remote-object-json-adapter-default-parameters-and-variadic.phpt
@@ -9,7 +9,7 @@ use ProxyManager\Factory\RemoteObject\AdapterInterface;
 
 interface FooServiceInterface
 {
-    public function fooBar(string $requiredParam, string $optionalParam = 'default');
+    public function fooBar(string $requiredParam, string $optionalParam = 'default', string ...$strs);
 }
 
 class CustomAdapter implements AdapterInterface
@@ -25,6 +25,12 @@ $factory = new \ProxyManager\Factory\RemoteObjectFactory(new CustomAdapter(), $c
 $proxy   = $factory->createProxy(FooServiceInterface::class);
 
 echo $proxy->fooBar('required') . "\n";
+echo $proxy->fooBar('required', 'passed') . "\n";
+echo $proxy->fooBar('required', 'passed', 'first_variadic') . "\n";
+echo $proxy->fooBar('required', 'passed', 'first_variadic', 'second_variadic') . "\n";
 ?>
 --EXPECTF--
 required,default
+required,passed
+required,passed,first_variadic
+required,passed,first_variadic,second_variadic

--- a/tests/language-feature-scripts/remote-object-json-adapter-passes-default-parameters-correctly.phpt
+++ b/tests/language-feature-scripts/remote-object-json-adapter-passes-default-parameters-correctly.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Verifies that generated remote object will pass default parameters in method declaration to Adapter.
+--FILE--
+<?php
+
+require_once __DIR__ . '/init.php';
+
+use ProxyManager\Factory\RemoteObject\AdapterInterface;
+
+interface FooServiceInterface
+{
+    public function fooBar(string $requiredParam, string $optionalParam = 'default');
+}
+
+class Foo implements FooServiceInterface
+{
+    public $foo = 'baz';
+
+    public function fooBar(string $requiredParam, string $optionalParam = 'default')
+    {
+        return 'bar';
+    }
+}
+
+class CustomAdapter implements AdapterInterface
+{
+    public function call(string $wrappedClass, string $method, array $params = [])
+    {
+        return \implode(',', $params);
+    }
+}
+
+$factory = new \ProxyManager\Factory\RemoteObjectFactory(new CustomAdapter(), $configuration);
+/** @var FooServiceInterface $proxy */
+$proxy   = $factory->createProxy(FooServiceInterface::class);
+
+echo $proxy->fooBar('required') . "\n";
+?>
+--EXPECTF--
+required,default


### PR DESCRIPTION
* Added new behaviour using introspection to figure out the default values for parameters that have not been passed.
* Added more tests regarding RemoteObjectMethod generation
  - Added functional tests with optional parameters
  - Added language feature testing with optional parameters
  - Added language feature testing with optional parameters mixed with variadic parameters
* Fixing PHPUnit 8 deprecations (for that had to install as dev-dependency zendframework/zend-server in order to be able to mock interface `\Zend\Server\Client`)
 

Fixes issue #539 

@Ocramius please let me know if there is something out of order, tried to make all files pass PSR-2/PSR-12.

If the changes regarding PHPUnit are too aggressive, let me know so I can revert those and keep the deprecated method usage (for more info: https://github.com/sebastianbergmann/phpunit/pull/3687)