### PR TITLE
Change missed occurences of zendframework

### DIFF
--- a/docs/remote-object.md
+++ b/docs/remote-object.md
@@ -14,13 +14,13 @@ be implemented both by the client and the RPC server.
 
 ## Adapters
 
-ZendFramework's RPC components (XmlRpc, JsonRpc & Soap) can be used with the remote object. You will need to require the one 
+Laminas's RPC components (XmlRpc, JsonRpc & Soap) can be used with the remote object. You will need to require the one 
 you need via composer:
 
 ```sh
-$ php composer.phar require zendframework/zend-xmlrpc:2.*
-$ php composer.phar require zendframework/zend-json:2.*
-$ php composer.phar require zendframework/zend-soap:2.*
+$ php composer.phar require laminas/laminas-xmlrpc:2.*
+$ php composer.phar require laminas/laminas-json:2.*
+$ php composer.phar require laminas/laminas-soap:2.*
 ```
 
 ProxyManager comes with 3 adapters:

--- a/examples/remote-proxy.php
+++ b/examples/remote-proxy.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 if (! class_exists('Laminas\XmlRpc\Client')) {
     echo "This example needs Laminas\\XmlRpc\\Client to run. \n In order to install it, "
         . "please run following:\n\n"
-        . "\$ php composer.phar require zendframework/zend-xmlrpc:2.*\n\n";
+        . "\$ php composer.phar require laminas/laminas-xmlrpc:2.*\n\n";
 
     exit(2);
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -25,7 +25,7 @@
     <issueHandlers>
         <UndefinedClass>
             <errorLevel type="suppress">
-                <!-- zendframework/zend-server is not a direct package nor build dependency, and it should stay that way -->
+                <!-- laminas/laminas-server is not a direct package nor build dependency, and it should stay that way -->
                 <referencedClass name="Laminas\Http\Client\Adapter\Exception\RuntimeException"/>
                 <referencedClass name="Laminas\Server\Client"/>
                 <referencedClass name="Laminas\XmlRpc\Server"/>


### PR DESCRIPTION
I missed some text occurences of zendframework in #546. This PR fixes them.

I noticed two aliases too:
ZendMethodGenerator
ZendClassGenerator

I don't know if we should change them too as it doesn't change anything.