### PR TITLE
Revert "Documented basic immutable/mutation-free interfaces and services in the package"

### DIFF
--- a/src/ProxyManager/Exception/DisabledMethodException.php
+++ b/src/ProxyManager/Exception/DisabledMethodException.php
@@ -9,8 +9,6 @@ use function sprintf;
 
 /**
  * Exception for forcefully disabled methods
- *
- * @psalm-immutable
  */
 class DisabledMethodException extends BadMethodCallException implements ExceptionInterface
 {

--- a/src/ProxyManager/Exception/ExceptionInterface.php
+++ b/src/ProxyManager/Exception/ExceptionInterface.php
@@ -8,8 +8,6 @@ use Throwable;
 
 /**
  * Base exception class for the proxy manager
- *
- * @psalm-immutable
  */
 interface ExceptionInterface extends Throwable
 {

--- a/src/ProxyManager/Exception/FileNotWritableException.php
+++ b/src/ProxyManager/Exception/FileNotWritableException.php
@@ -10,8 +10,6 @@ use function sprintf;
 
 /**
  * Exception for non writable files
- *
- * @psalm-immutable
  */
 class FileNotWritableException extends UnexpectedValueException implements ExceptionInterface
 {

--- a/src/ProxyManager/Exception/InvalidProxiedClassException.php
+++ b/src/ProxyManager/Exception/InvalidProxiedClassException.php
@@ -14,8 +14,6 @@ use function sprintf;
 
 /**
  * Exception for invalid proxied classes
- *
- * @psalm-immutable
  */
 class InvalidProxiedClassException extends InvalidArgumentException implements ExceptionInterface
 {

--- a/src/ProxyManager/Exception/InvalidProxyDirectoryException.php
+++ b/src/ProxyManager/Exception/InvalidProxyDirectoryException.php
@@ -9,8 +9,6 @@ use function sprintf;
 
 /**
  * Exception for invalid directories
- *
- * @psalm-immutable
  */
 class InvalidProxyDirectoryException extends InvalidArgumentException implements ExceptionInterface
 {

--- a/src/ProxyManager/Exception/UnsupportedProxiedClassException.php
+++ b/src/ProxyManager/Exception/UnsupportedProxiedClassException.php
@@ -14,8 +14,6 @@ use function sprintf;
 
 /**
  * Exception for invalid proxied classes
- *
- * @psalm-immutable
  */
 class UnsupportedProxiedClassException extends LogicException implements ExceptionInterface
 {

--- a/src/ProxyManager/FileLocator/FileLocator.php
+++ b/src/ProxyManager/FileLocator/FileLocator.php
@@ -11,8 +11,6 @@ use function str_replace;
 
 /**
  * {@inheritDoc}
- *
- * @psalm-immutable
  */
 class FileLocator implements FileLocatorInterface
 {

--- a/src/ProxyManager/Generator/ClassGenerator.php
+++ b/src/ProxyManager/Generator/ClassGenerator.php
@@ -10,8 +10,6 @@ use function trim;
 
 /**
  * Class generator that ensures that interfaces/classes that are implemented/extended are FQCNs
- *
- * @psalm-external-mutation-free
  */
 class ClassGenerator extends ZendClassGenerator
 {

--- a/src/ProxyManager/Generator/MagicMethodGenerator.php
+++ b/src/ProxyManager/Generator/MagicMethodGenerator.php
@@ -9,8 +9,6 @@ use function strtolower;
 
 /**
  * Method generator for magic methods
- *
- * @psalm-external-mutation-free
  */
 class MagicMethodGenerator extends MethodGenerator
 {

--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -10,8 +10,6 @@ use Laminas\Code\Reflection\MethodReflection;
 
 /**
  * Method generator that fixes minor quirks in ZF2's method generator
- *
- * @psalm-external-mutation-free
  */
 class MethodGenerator extends ZendMethodGenerator
 {

--- a/src/ProxyManager/Generator/Util/IdentifierSuffixer.php
+++ b/src/ProxyManager/Generator/Util/IdentifierSuffixer.php
@@ -16,8 +16,6 @@ use function substr;
  * with a deterministic attached suffix,
  * in order to prevent property name collisions
  * and tampering from userland
- *
- * @psalm-immutable
  */
 abstract class IdentifierSuffixer
 {

--- a/src/ProxyManager/Generator/Util/ProxiedMethodReturnExpression.php
+++ b/src/ProxyManager/Generator/Util/ProxiedMethodReturnExpression.php
@@ -10,8 +10,6 @@ use ReflectionMethod;
  * Utility class to generate return expressions in method, given a method signature.
  *
  * This is required since return expressions may be forbidden by the method signature (void).
- *
- * @psalm-immutable
  */
 final class ProxiedMethodReturnExpression
 {

--- a/src/ProxyManager/Generator/Util/UniqueIdentifierGenerator.php
+++ b/src/ProxyManager/Generator/Util/UniqueIdentifierGenerator.php
@@ -11,8 +11,6 @@ use function uniqid;
 /**
  * Utility class capable of generating unique
  * valid class/property/method identifiers
- *
- * @psalm-immutable
  */
 abstract class UniqueIdentifierGenerator
 {

--- a/src/ProxyManager/Inflector/ClassNameInflector.php
+++ b/src/ProxyManager/Inflector/ClassNameInflector.php
@@ -13,8 +13,6 @@ use function substr;
 
 /**
  * {@inheritDoc}
- *
- * @psalm-immutable
  */
 final class ClassNameInflector implements ClassNameInflectorInterface
 {

--- a/src/ProxyManager/Inflector/ClassNameInflectorInterface.php
+++ b/src/ProxyManager/Inflector/ClassNameInflectorInterface.php
@@ -8,8 +8,6 @@ use ProxyManager\Proxy\ProxyInterface;
 
 /**
  * Interface for a proxy- to user-class and user- to proxy-class name inflector
- *
- * @psalm-immutable
  */
 interface ClassNameInflectorInterface
 {

--- a/src/ProxyManager/Inflector/Util/ParameterEncoder.php
+++ b/src/ProxyManager/Inflector/Util/ParameterEncoder.php
@@ -9,8 +9,6 @@ use function serialize;
 
 /**
  * Encodes parameters into a class-name safe string
- *
- * @psalm-immutable
  */
 class ParameterEncoder
 {

--- a/src/ProxyManager/Inflector/Util/ParameterHasher.php
+++ b/src/ProxyManager/Inflector/Util/ParameterHasher.php
@@ -9,8 +9,6 @@ use function serialize;
 
 /**
  * Converts given parameters into a likely unique hash
- *
- * @psalm-immutable
  */
 class ParameterHasher
 {

--- a/src/ProxyManager/Proxy/Exception/RemoteObjectException.php
+++ b/src/ProxyManager/Proxy/Exception/RemoteObjectException.php
@@ -10,8 +10,6 @@ use RuntimeException;
  * Remote object exception
  *
  * @deprecated this exception is not in use anymore, and should not be relied upon
- *
- * @psalm-immutable
  */
 class RemoteObjectException extends RuntimeException
 {

--- a/src/ProxyManager/ProxyGenerator/Assertion/CanProxyAssertion.php
+++ b/src/ProxyManager/ProxyGenerator/Assertion/CanProxyAssertion.php
@@ -12,8 +12,6 @@ use function array_filter;
 
 /**
  * Assertion that verifies that a class can be proxied
- *
- * @psalm-immutable
  */
 final class CanProxyAssertion
 {

--- a/src/ProxyManager/ProxyGenerator/Util/GetMethodIfExists.php
+++ b/src/ProxyManager/ProxyGenerator/Util/GetMethodIfExists.php
@@ -9,8 +9,6 @@ use ReflectionMethod;
 
 /**
  * Internal utility class - allows fetching a method from a given class, if it exists
- *
- * @psalm-immutable
  */
 final class GetMethodIfExists
 {

--- a/src/ProxyManager/ProxyGenerator/Util/Properties.php
+++ b/src/ProxyManager/ProxyGenerator/Util/Properties.php
@@ -18,8 +18,6 @@ use function array_values;
 /**
  * DTO containing the list of all non-static proxy properties and utility methods to access them
  * in various formats/collections
- *
- * @psalm-immutable
  */
 final class Properties
 {

--- a/src/ProxyManager/ProxyGenerator/Util/ProxiedMethodsFilter.php
+++ b/src/ProxyManager/ProxyGenerator/Util/ProxiedMethodsFilter.php
@@ -15,8 +15,6 @@ use function strtolower;
 
 /**
  * Utility class used to filter methods that can be proxied
- *
- * @psalm-immutable
  */
 final class ProxiedMethodsFilter
 {

--- a/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
@@ -12,8 +12,6 @@ use function sprintf;
  * Generates code necessary to simulate a fatal error in case of unauthorized
  * access to class members in magic methods even when in child classes and dealing
  * with protected members.
- *
- * @psalm-immutable
  */
 class PublicScopeSimulator
 {

--- a/src/ProxyManager/ProxyGenerator/Util/UnsetPropertiesGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/UnsetPropertiesGenerator.php
@@ -14,8 +14,6 @@ use function var_export;
 
 /**
  * Generates code necessary to unset all the given properties from a particular given instance string name
- *
- * @psalm-immutable
  */
 final class UnsetPropertiesGenerator
 {

--- a/src/ProxyManager/Signature/Exception/ExceptionInterface.php
+++ b/src/ProxyManager/Signature/Exception/ExceptionInterface.php
@@ -6,8 +6,6 @@ namespace ProxyManager\Signature\Exception;
 
 /**
  * Exception marker for exceptions from the signature sub-component
- *
- * @psalm-immutable
  */
 interface ExceptionInterface
 {

--- a/src/ProxyManager/Signature/Exception/InvalidSignatureException.php
+++ b/src/ProxyManager/Signature/Exception/InvalidSignatureException.php
@@ -11,8 +11,6 @@ use function sprintf;
 
 /**
  * Exception for invalid provided signatures
- *
- * @psalm-immutable
  */
 class InvalidSignatureException extends UnexpectedValueException implements ExceptionInterface
 {

--- a/src/ProxyManager/Signature/Exception/MissingSignatureException.php
+++ b/src/ProxyManager/Signature/Exception/MissingSignatureException.php
@@ -11,8 +11,6 @@ use function sprintf;
 
 /**
  * Exception for no found signatures
- *
- * @psalm-immutable
  */
 class MissingSignatureException extends UnexpectedValueException implements ExceptionInterface
 {

--- a/src/ProxyManager/Signature/SignatureChecker.php
+++ b/src/ProxyManager/Signature/SignatureChecker.php
@@ -12,8 +12,6 @@ use function is_string;
 
 /**
  * Generator for signatures to be used to check the validity of generated code
- *
- * @psalm-external-mutation-free
  */
 final class SignatureChecker implements SignatureCheckerInterface
 {

--- a/src/ProxyManager/Signature/SignatureCheckerInterface.php
+++ b/src/ProxyManager/Signature/SignatureCheckerInterface.php
@@ -10,8 +10,6 @@ use ReflectionClass;
 
 /**
  * Generator for signatures to be used to check the validity of generated code
- *
- * @psalm-immutable
  */
 interface SignatureCheckerInterface
 {

--- a/src/ProxyManager/Signature/SignatureGenerator.php
+++ b/src/ProxyManager/Signature/SignatureGenerator.php
@@ -9,8 +9,6 @@ use ProxyManager\Inflector\Util\ParameterHasher;
 
 /**
  * {@inheritDoc}
- *
- * @psalm-immutable
  */
 final class SignatureGenerator implements SignatureGeneratorInterface
 {

--- a/src/ProxyManager/Signature/SignatureGeneratorInterface.php
+++ b/src/ProxyManager/Signature/SignatureGeneratorInterface.php
@@ -6,8 +6,6 @@ namespace ProxyManager\Signature;
 
 /**
  * Generator for signatures to be used to check the validity of generated code
- *
- * @psalm-immutable
  */
 interface SignatureGeneratorInterface
 {

--- a/src/ProxyManager/Stub/EmptyClassStub.php
+++ b/src/ProxyManager/Stub/EmptyClassStub.php
@@ -6,8 +6,6 @@ namespace ProxyManager\Stub;
 
 /**
  * Just an empty instantiable class
- *
- * @psalm-immutable
  */
 final class EmptyClassStub
 {

--- a/src/ProxyManager/Version.php
+++ b/src/ProxyManager/Version.php
@@ -11,8 +11,6 @@ use PackageVersions\Versions;
  * Version class
  *
  * Note that we cannot check the version at runtime via `git` because that would cause a lot of I/O operations.
- *
- * @psalm-immutable
  */
 final class Version
 {


### PR DESCRIPTION
Reverts Ocramius/ProxyManager#502

Turns out that #502 was a mess: needs revert, since its last build was done before inheritance played any role in psalm inspections.