### PR TITLE
Fix signatures to static

### DIFF
--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -14,11 +14,11 @@ use Laminas\Code\Reflection\MethodReflection;
 class MethodGenerator extends ZendMethodGenerator
 {
     /**
-     * {@inheritDoc}
+     * @return static
      */
     public static function fromReflectionWithoutBodyAndDocBlock(MethodReflection $reflectionMethod) : self
     {
-        /** @var self $method */
+        /** @var static $method */
         $method = parent::copyMethodSignature($reflectionMethod);
 
         $method->setInterface(false);

--- a/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptor.php
+++ b/src/ProxyManager/ProxyGenerator/NullObject/MethodGenerator/NullObjectMethodInterceptor.php
@@ -14,11 +14,11 @@ use ProxyManager\Generator\Util\IdentifierSuffixer;
 class NullObjectMethodInterceptor extends MethodGenerator
 {
     /**
-     * @return self|static
+     * @return static
      */
     public static function generateMethod(MethodReflection $originalMethod) : self
     {
-        /** @var self $method */
+        /** @var static $method */
         $method = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
 
         if ($originalMethod->returnsReference()) {

--- a/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
+++ b/src/ProxyManager/ProxyGenerator/RemoteObject/MethodGenerator/RemoteObjectMethod.php
@@ -28,13 +28,13 @@ $args = \func_get_args() + $defaultValues;
 #PROXIED_RETURN#
 PHP;
 
-    /** @return self|static */
+    /** @return static */
     public static function generateMethod(
         MethodReflection $originalMethod,
         PropertyGenerator $adapterProperty,
         ReflectionClass $originalClass
     ) : self {
-        /** @var self $method */
+        /** @var static $method */
         $method        = static::fromReflectionWithoutBodyAndDocBlock($originalMethod);
         $proxiedReturn = '$return = $this->' . $adapterProperty->getName()
             . '->call(' . var_export($originalClass->getName(), true)


### PR DESCRIPTION
Latest master version of Psalm is a bit stricter about when you can use `static`.