### PR TITLE
Fix newly-prevented issues

### DIFF
--- a/examples/virtual-proxy.php
+++ b/examples/virtual-proxy.php
@@ -31,7 +31,7 @@ class Foo
         $proxy = $factory->createProxy(
             Foo::class,
             static function (
-                ?object & $wrappedObject, ?object $proxy, string $method, array $parameters, ?Closure & $initializer
+                ?Foo & $wrappedObject, ?object $proxy, string $method, array $parameters, ?Closure & $initializer
             ) {
                 $initializer = null;
                 $wrappedObject = new Foo();

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,36 +32,18 @@
                 <referencedClass name="Laminas\XmlRpc\Client"/>
             </errorLevel>
         </UndefinedClass>
-        <LessSpecificReturnType errorLevel="error"/>
 
-        <DeprecatedMethod errorLevel="error"/>
-        <DeprecatedProperty errorLevel="error"/>
-        <DeprecatedClass errorLevel="error"/>
-        <DeprecatedConstant errorLevel="error"/>
-        <DeprecatedInterface errorLevel="error"/>
-        <DeprecatedTrait errorLevel="error"/>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+        </DeprecatedMethod>
 
         <ForbiddenCode errorLevel="suppress"/>
 
         <InternalMethod errorLevel="suppress"/>
-        <InternalProperty errorLevel="error"/>
-        <InternalClass errorLevel="error"/>
-
-        <MissingClosureReturnType errorLevel="error"/>
-        <MissingReturnType errorLevel="error"/>
-        <MissingPropertyType errorLevel="error"/>
-        <InvalidDocblock errorLevel="error"/>
-        <MisplacedRequiredParam errorLevel="error"/>
 
         <PropertyNotSetInConstructor errorLevel="suppress"/>
-        <MissingConstructor errorLevel="error"/>
-        <MissingClosureParamType errorLevel="error"/>
-        <MissingParamType errorLevel="error"/>
-        <RedundantCondition errorLevel="error"/>
-        <DocblockTypeContradiction errorLevel="error"/>
-        <RedundantConditionGivenDocblockType errorLevel="error"/>
-        <RawObjectIteration errorLevel="error"/>
-        <InvalidStringClass errorLevel="error"/>
 
         <UnresolvableInclude errorLevel="suppress"/>
     </issueHandlers>

--- a/tests/ProxyManagerBench/LazyLoadingGhostPropertyAccessBench.php
+++ b/tests/ProxyManagerBench/LazyLoadingGhostPropertyAccessBench.php
@@ -56,6 +56,9 @@ final class LazyLoadingGhostPropertyAccessBench
     /** @var ClassWithMixedProperties&LazyLoadingInterface */
     private ClassWithMixedProperties $initializedMixedPropertiesProxy;
 
+    /**
+     * @psalm-suppress RedundantConditionGivenDocblockType
+     */
     public function setUp() : void
     {
         $emptyClassProxy                     = $this->buildProxy(EmptyClass::class);

--- a/tests/ProxyManagerBench/LazyLoadingValueHolderPropertyAccessBench.php
+++ b/tests/ProxyManagerBench/LazyLoadingValueHolderPropertyAccessBench.php
@@ -44,6 +44,9 @@ final class LazyLoadingValueHolderPropertyAccessBench
     /** @var ClassWithMixedProperties&VirtualProxyInterface */
     private ClassWithMixedProperties $initializedMixedPropertiesProxy;
 
+    /**
+     * @psalm-suppress RedundantConditionGivenDocblockType
+     */
     public function setUp() : void
     {
         $emptyClassProxy                  = $this->buildProxy(EmptyClass::class);

--- a/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/LazyLoadingValueHolderFunctionalTest.php
@@ -280,7 +280,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
 
         $proxy = (new LazyLoadingValueHolderFactory())->createProxy(
             BaseClass::class,
-            static function (?object & $wrappedInstance) use (& $counter) : bool {
+            static function (?BaseClass & $wrappedInstance) use (& $counter) : bool {
                 $wrappedInstance = new BaseClass();
 
                 /** @var int $counter */
@@ -335,7 +335,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
     {
         $object = (new LazyLoadingValueHolderFactory())->createProxy(
             ClassWithMethodWithByRefVariadicFunction::class,
-            static function (?object & $wrappedInstance) : bool {
+            static function (?ClassWithMethodWithByRefVariadicFunction & $wrappedInstance) : bool {
                 $wrappedInstance = new ClassWithMethodWithByRefVariadicFunction();
 
                 return true;
@@ -360,7 +360,7 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
     {
         $object = (new LazyLoadingValueHolderFactory())->createProxy(
             ClassWithDynamicArgumentsMethod::class,
-            static function (?object & $wrappedInstance) : bool {
+            static function (?ClassWithDynamicArgumentsMethod & $wrappedInstance) : bool {
                 $wrappedInstance = new ClassWithDynamicArgumentsMethod();
 
                 return true;
@@ -375,15 +375,19 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
     }
 
     /**
+     * @template TClass
+     *
+     * @psalm-param (CallableInterface&Mock)|null $initializerMatcher
+     * @psalm-param class-string<TClass> $className
+     * @psalm-param TClass $realInstance
+     *
      * @return Closure(
-     *  object|null,
+     *  TClass|null,
      *  VirtualProxyInterface,
      *  string,
      *  array,
      *  ?Closure
      * ) : bool
-     *
-     * @psalm-param (CallableInterface&Mock)|null $initializerMatcher
      */
     private function createInitializer(string $className, object $realInstance, ?Mock $initializerMatcher = null) : Closure
     {
@@ -402,7 +406,11 @@ final class LazyLoadingValueHolderFunctionalTest extends TestCase
                 );
         }
 
-        return static function (
+        return
+        /**
+         * @psalm-param ?TClass $wrappedObject
+         */
+        static function (
             ?object & $wrappedObject,
             VirtualProxyInterface $proxy,
             string $method,

--- a/tests/static-analysis/lazy-loading-value-holder.php
+++ b/tests/static-analysis/lazy-loading-value-holder.php
@@ -20,7 +20,7 @@ class MyProxiedClass
         ->createProxy(
             MyProxiedClass::class,
             static function (
-                ?object & $instance,
+                ?MyProxiedClass & $instance,
                 LazyLoadingInterface $proxy,
                 string $method,
                 array $parameters,
@@ -36,7 +36,7 @@ class MyProxiedClass
 
     $valueHolder = (new LazyLoadingValueHolderFactory())
         ->createProxy(MyProxiedClass::class, static function (
-            ?object & $wrappedObject,
+            ?MyProxiedClass & $wrappedObject,
             LazyLoadingInterface $proxy,
             string $method,
             array $parameters,


### PR DESCRIPTION
Psalm had a bit of an issue understanding interpreting partially matching templates (`$a` was previously inferred as `object` in [this example](https://psalm.dev/r/1ad54ea020), now it's inferred as `A`). 

This means that Psalm (latest master) now finds a few additional issues in the tests and example code.