### PR TITLE
#574 remove support for PHP 7.4.1 and newer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ cache: false
 sudo: false
 
 php:
-  - 7.4
-  - nightly
+  - 7.4.0
 
 env:
   matrix:
@@ -39,10 +38,6 @@ script:
   - ./vendor/bin/phpcs
   - ./vendor/bin/psalm
   - ulimit -n 4096 && phpdbg -qrr ./vendor/bin/infection -vvv --test-framework-options='--testsuite=unit' --min-msi=84 --min-covered-msi=86
-
-matrix:
-  allow_failures:
-    - php: nightly
 
 after_script:
   - sh .travis.coverage.sh

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php":                       "7.4.*",
+        "php":                       "7.4.0",
         "laminas/laminas-code":      "^3.4.1",
         "ocramius/package-versions": "^1.5.1",
         "webimpress/safe-writer":    "^2.0"


### PR DESCRIPTION
PHP 7.4.1 broke backward compatibility in which public typed properties no longer trigger `__get`
calls when not initialized, and must be explicitly unset instead. This is incompatible with the
`2.7.x` releases of `ocramius/proxy-manager`, so we intentionally remove compatibility to allow
downstream clients to either upgrade to `2.8.0` or `2.7.1` (if they are running *exactly* PHP
7.4.0).

Ref: https://bugs.php.net/bug.php?id=79373

Fixes #574