### PR TITLE
Add psalm's github workflow 

### DIFF
--- a/.github/workflows/shepherd.yml
+++ b/.github/workflows/shepherd.yml
@@ -1,0 +1,18 @@
+name: Run Shepherd
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
+
+      - name: Run Psalm
+        run: ./vendor/bin/psalm --threads=2 --output-format=github --shepherd


### PR DESCRIPTION
`Psalm` can comment at file lines where it finds issues.

E.g.:
![80582776-96f4f580-8a0f-11ea-88fd-445c48c9fce6](https://user-images.githubusercontent.com/3275172/81693970-041d7780-9461-11ea-9aaf-b28cc7cc124d.png)
