### PR TITLE
#617 removed compatibility with `ocramius/package-versions:1.10.0` and newer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php":                       "~7.4.1",
         "laminas/laminas-code":      "^3.4.1",
-        "ocramius/package-versions": "^1.8.0",
+        "ocramius/package-versions": "^1.8.0,<1.10.0",
         "webimpress/safe-writer":    "^2.0.1"
     },
     "conflict": {


### PR DESCRIPTION
Due to a change in `ocramius/package-versions` internals, and my own mistake in
not detecting that `PackageVersions\Versions::VERSIONS` was marked as `@internal`
(note: annotations on constants are not really picked up by reflection, and therefore
not by static analysis tools either), we had a pretty abrupt crash when upgrading
to `ocramius/package-versions:1.10.0`.

In practice, `PackageVersions\Versions::VERSIONS` is hashed in order to prefix the
name of generated proxy classes, therefore ensuring that no proxy classes would
be re-used when underlying dependency versions change: while this design worked really
well, it relied on accessing the `PackageVersions\Versions::VERSIONS` constant, which
was never part of the `ocramius/package-versions` API, and which was removed in an
internal refactoring of `ocramius/package-versions:1.10.0`.

This change is only in place to prevent installation of `ocramius/package-versions:1.10.0`,
while a subsequent patch will be made to phase out said package, to be replaced with
direct usage of `composer-runtime-api:^2`, which comes with composer 2.x.

Fixes #617 