### PR TITLE
Fix Versions checking for ocramius/package-versions instead of ocramius/proxy-manager

### DIFF
--- a/src/ProxyManager/Version.php
+++ b/src/ProxyManager/Version.php
@@ -34,7 +34,7 @@ final class Version
      */
     public static function getVersion(): string
     {
-        return InstalledVersions::getPrettyVersion('ocramius/package-versions')
-            . '@' . InstalledVersions::getReference('ocramius/package-versions');
+        return InstalledVersions::getPrettyVersion('ocramius/proxy-manager')
+            . '@' . InstalledVersions::getReference('ocramius/proxy-manager');
     }
 }


### PR DESCRIPTION
Unless I missed something, this looks like a typo.
A local project is failing with `Package "ocramius/package-versions" is not installed` currently.