### PR TITLE
Add "skipDestructor" option to lazy loading proxies

### DIFF
--- a/src/ProxyManager/Factory/AbstractBaseFactory.php
+++ b/src/ProxyManager/Factory/AbstractBaseFactory.php
@@ -17,6 +17,8 @@ use function array_key_exists;
 use function assert;
 use function class_exists;
 use function is_a;
+use function serialize;
+use function sha1;
 
 /**
  * Base factory common logic
@@ -29,7 +31,7 @@ abstract class AbstractBaseFactory
      * Cached checked class names
      *
      * @var array<string, string>
-     * @psalm-var array<class-string, class-string>
+     * @psalm-var array<string, class-string>
      */
     private array $checkedClasses = [];
 
@@ -54,8 +56,10 @@ abstract class AbstractBaseFactory
      */
     protected function generateProxy(string $className, array $proxyOptions = []): string
     {
-        if (array_key_exists($className, $this->checkedClasses)) {
-            $generatedClassName = $this->checkedClasses[$className];
+        $cacheKey = $proxyOptions ? sha1(serialize([$className, $proxyOptions])) : $className;
+
+        if (array_key_exists($cacheKey, $this->checkedClasses)) {
+            $generatedClassName = $this->checkedClasses[$cacheKey];
 
             assert(is_a($generatedClassName, $className, true));
 
@@ -87,7 +91,7 @@ abstract class AbstractBaseFactory
             ->getSignatureChecker()
             ->checkSignature(new ReflectionClass($proxyClassName), $proxyParameters);
 
-        return $this->checkedClasses[$className] = $proxyClassName;
+        return $this->checkedClasses[$cacheKey] = $proxyClassName;
     }
 
     abstract protected function getGenerator(): ProxyGeneratorInterface;

--- a/src/ProxyManager/Factory/LazyLoadingValueHolderFactory.php
+++ b/src/ProxyManager/Factory/LazyLoadingValueHolderFactory.php
@@ -35,6 +35,7 @@ class LazyLoadingValueHolderFactory extends AbstractBaseFactory
      *   array<string, mixed>=,
      *   ?Closure=
      * ) : bool $initializer
+     * @psalm-param array{skipDestructor?: bool} $proxyOptions
      *
      * @psalm-return RealObjectType&ValueHolderInterface<RealObjectType>&VirtualProxyInterface
      *

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/SkipDestructor.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhost/MethodGenerator/SkipDestructor.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManager\ProxyGenerator\LazyLoadingGhost\MethodGenerator;
+
+use Laminas\Code\Generator\Exception\InvalidArgumentException;
+use Laminas\Code\Generator\PropertyGenerator;
+use ProxyManager\Generator\MethodGenerator;
+
+/**
+ * Destructor that skips the original destructor when the proxy is not initialized.
+ */
+class SkipDestructor extends MethodGenerator
+{
+    /**
+     * Constructor
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(PropertyGenerator $initializerProperty)
+    {
+        parent::__construct('__destruct');
+
+        $this->setBody(
+            '$this->' . $initializerProperty->getName() . ' || parent::__destruct();'
+        );
+    }
+}

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingGhostGenerator.php
@@ -25,6 +25,7 @@ use ProxyManager\ProxyGenerator\LazyLoadingGhost\MethodGenerator\MagicSet;
 use ProxyManager\ProxyGenerator\LazyLoadingGhost\MethodGenerator\MagicSleep;
 use ProxyManager\ProxyGenerator\LazyLoadingGhost\MethodGenerator\MagicUnset;
 use ProxyManager\ProxyGenerator\LazyLoadingGhost\MethodGenerator\SetProxyInitializer;
+use ProxyManager\ProxyGenerator\LazyLoadingGhost\MethodGenerator\SkipDestructor;
 use ProxyManager\ProxyGenerator\LazyLoadingGhost\PropertyGenerator\InitializationTracker;
 use ProxyManager\ProxyGenerator\LazyLoadingGhost\PropertyGenerator\InitializerProperty;
 use ProxyManager\ProxyGenerator\LazyLoadingGhost\PropertyGenerator\PrivatePropertiesMap;
@@ -48,7 +49,7 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
     /**
      * {@inheritDoc}
      *
-     * @psalm-param array{skippedProperties?: array<int, string>} $proxyOptions
+     * @psalm-param array{skippedProperties?: array<int, string>, skipDestructor?: bool} $proxyOptions
      *
      * @return void
      *
@@ -65,6 +66,7 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
         $publicProperties    = new PublicPropertiesMap($filteredProperties);
         $privateProperties   = new PrivatePropertiesMap($filteredProperties);
         $protectedProperties = new ProtectedPropertiesMap($filteredProperties);
+        $skipDestructor      = ($proxyOptions['skipDestructor'] ?? false) && $originalClass->hasMethod('__destruct');
 
         $classGenerator->setExtendedClass($originalClass->getName());
         $classGenerator->setImplementedInterfaces([GhostObjectInterface::class]);
@@ -81,7 +83,7 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
                 ClassGeneratorUtils::addMethodIfNotFinal($originalClass, $classGenerator, $generatedMethod);
             },
             array_merge(
-                $this->getAbstractProxiedMethods($originalClass),
+                $this->getAbstractProxiedMethods($originalClass, $skipDestructor),
                 [
                     $init,
                     new StaticProxyConstructor($initializer, $filteredProperties),
@@ -124,7 +126,8 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
                     new GetProxyInitializer($initializer),
                     new InitializeProxy($initializer, $init),
                     new IsProxyInitialized($initializer),
-                ]
+                ],
+                $skipDestructor ? [new SkipDestructor($initializer)] : []
             )
         );
     }
@@ -134,8 +137,22 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
      *
      * @return MethodGenerator[]
      */
-    private function getAbstractProxiedMethods(ReflectionClass $originalClass): array
+    private function getAbstractProxiedMethods(ReflectionClass $originalClass, bool $skipDestructor): array
     {
+        $excludedMethods = [
+            '__get',
+            '__set',
+            '__isset',
+            '__unset',
+            '__clone',
+            '__sleep',
+            '__wakeup',
+        ];
+
+        if ($skipDestructor) {
+            $excludedMethods[] = '__destruct';
+        }
+
         return array_map(
             static function (ReflectionMethod $method): ProxyManagerMethodGenerator {
                 $generated = ProxyManagerMethodGenerator::fromReflectionWithoutBodyAndDocBlock(
@@ -146,7 +163,7 @@ class LazyLoadingGhostGenerator implements ProxyGeneratorInterface
 
                 return $generated;
             },
-            ProxiedMethodsFilter::getAbstractProxiedMethods($originalClass)
+            ProxiedMethodsFilter::getAbstractProxiedMethods($originalClass, $excludedMethods)
         );
     }
 }

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/SkipDestructor.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/SkipDestructor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManager\ProxyGenerator\LazyLoadingValueHolder\MethodGenerator;
+
+use Laminas\Code\Generator\PropertyGenerator;
+use ProxyManager\Generator\MethodGenerator;
+use ReflectionClass;
+
+/**
+ * Destructor that skips the original destructor when the proxy is not initialized.
+ */
+class SkipDestructor extends MethodGenerator
+{
+    /**
+     * Constructor
+     */
+    public function __construct(
+        PropertyGenerator $initializerProperty,
+        PropertyGenerator $valueHolderProperty
+    ) {
+        parent::__construct('__destruct');
+
+        $initializer = $initializerProperty->getName();
+        $valueHolder = $valueHolderProperty->getName();
+
+        $this->setBody(
+            '$this->' . $initializer . ' || $this->' . $valueHolder . '->__destruct();'
+        );
+    }
+}

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
@@ -25,6 +25,7 @@ use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\MethodGenerator\MagicSet;
 use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\MethodGenerator\MagicSleep;
 use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\MethodGenerator\MagicUnset;
 use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\MethodGenerator\SetProxyInitializer;
+use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\MethodGenerator\SkipDestructor;
 use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\PropertyGenerator\InitializerProperty;
 use ProxyManager\ProxyGenerator\LazyLoadingValueHolder\PropertyGenerator\ValueHolderProperty;
 use ProxyManager\ProxyGenerator\PropertyGenerator\PublicPropertiesMap;
@@ -48,12 +49,14 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
     /**
      * {@inheritDoc}
      *
+     * @psalm-param array{skipDestructor?: bool} $proxyOptions
+     *
      * @return void
      *
      * @throws InvalidProxiedClassException
      * @throws InvalidArgumentException
      */
-    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator, array $proxyOptions = [])
     {
         CanProxyAssertion::assertClassCanBeProxied($originalClass);
 
@@ -71,6 +74,21 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
         $classGenerator->addPropertyFromGenerator($initializer = new InitializerProperty());
         $classGenerator->addPropertyFromGenerator($publicProperties);
 
+        $skipDestructor  = ($proxyOptions['skipDestructor'] ?? false) && $originalClass->hasMethod('__destruct');
+        $excludedMethods = [
+            '__get',
+            '__set',
+            '__isset',
+            '__unset',
+            '__clone',
+            '__sleep',
+            '__wakeup',
+        ];
+
+        if ($skipDestructor) {
+            $excludedMethods[] = '__destruct';
+        }
+
         array_map(
             static function (MethodGenerator $generatedMethod) use ($originalClass, $classGenerator): void {
                 ClassGeneratorUtils::addMethodIfNotFinal($originalClass, $classGenerator, $generatedMethod);
@@ -78,7 +96,7 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
             array_merge(
                 array_map(
                     $this->buildLazyLoadingMethodInterceptor($initializer, $valueHolder),
-                    ProxiedMethodsFilter::getProxiedMethods($originalClass)
+                    ProxiedMethodsFilter::getProxiedMethods($originalClass, $excludedMethods)
                 ),
                 [
                     new StaticProxyConstructor($initializer, Properties::fromReflectionClass($originalClass)),
@@ -95,7 +113,8 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
                     new InitializeProxy($initializer, $valueHolder),
                     new IsProxyInitialized($valueHolder),
                     new GetWrappedValueHolderValue($valueHolder),
-                ]
+                ],
+                $skipDestructor ? [new SkipDestructor($initializer, $valueHolder)] : []
             )
         );
     }

--- a/tests/language-feature-scripts/lazy-loading-ghost-skip-destructor.phpt
+++ b/tests/language-feature-scripts/lazy-loading-ghost-skip-destructor.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Verifies that generated lazy loading ghost objects can skip calling the proxied destructor
+--FILE--
+<?php
+
+require_once __DIR__ . '/init.php';
+
+class Destructable
+{
+    public function __destruct()
+    {
+        echo __FUNCTION__;
+    }
+}
+
+$factory = new \ProxyManager\Factory\LazyLoadingGhostFactory($configuration);
+
+$init = function ($object, $method, $parameters, & $initializer) {
+    echo 'init';
+    $initializer = null;
+};
+
+$proxy = $factory->createProxy(Destructable::class, $init, ['skipDestructor' => true]);
+echo "NO __destruct\n";
+unset($proxy);
+
+$proxy = $factory->createProxy(Destructable::class, $init, ['skipDestructor' => true]);
+echo 'DO ';
+$proxy->triggerInit = true;
+unset($proxy);
+
+$proxy = $factory->createProxy(Destructable::class, $init);
+echo "\nDO ";
+unset($proxy);
+?>
+--EXPECT--
+NO __destruct
+DO init__destruct
+DO __destruct

--- a/tests/language-feature-scripts/lazy-loading-value-holder-skip-destructor.phpt
+++ b/tests/language-feature-scripts/lazy-loading-value-holder-skip-destructor.phpt
@@ -1,0 +1,40 @@
+--TEST--
+Verifies that generated lazy loading value holders can skip calling the proxied destructor
+--FILE--
+<?php
+
+require_once __DIR__ . '/init.php';
+
+class Destructable
+{
+    public function __destruct()
+    {
+        echo __FUNCTION__;
+    }
+}
+
+$factory = new \ProxyManager\Factory\LazyLoadingValueHolderFactory($configuration);
+
+$init = function (& $wrapped, $proxy, $method, $parameters, & $initializer) {
+    echo 'init';
+    $wrapped = new Destructable();
+    $initializer = null;
+};
+
+$proxy = $factory->createProxy(Destructable::class, $init, ['skipDestructor' => true]);
+echo "NO __destruct\n";
+unset($proxy);
+
+$proxy = $factory->createProxy(Destructable::class, $init, ['skipDestructor' => true]);
+echo "DO ";
+$proxy->triggerInit = true;
+unset($proxy);
+
+$proxy = $factory->createProxy(Destructable::class, $init);
+echo "\nDO ";
+unset($proxy);
+?>
+--EXPECT--
+NO __destruct
+DO init__destruct__destruct
+DO init__destruct__destruct


### PR DESCRIPTION
This PR adds a new `skipDestructor` option to lazy proxies (ghosts and value holders) that skips calling the original destructor when the object is not initialized.

This is something that is much needed in DI containers, where e.g. we don't want opening a database connection on an unused Doctrine object.

For the record, Symfony already has a similar check in place, but it is implemented using monkey-patching. Because of the policies in place here (new features are available only on the very latest PHP version), I had absolutely no incentive in contributing here since I couldn't actually use that work anytime soon.

Now that I decided to [maintain a fork of this code](https://github.com/Ocramius/ProxyManager/issues/630#issuecomment-746158099), I know that anything I contribute here could be used in the short term.  That's a great incentive.

The good news is that you don't have to change your policies. OSS dynamics FTW here also.