### PR TITLE
Add "fluentSafe" option to LazyLoadingValueHolderGenerator

### DIFF
--- a/src/ProxyManager/Factory/LazyLoadingValueHolderFactory.php
+++ b/src/ProxyManager/Factory/LazyLoadingValueHolderFactory.php
@@ -38,6 +38,7 @@ class LazyLoadingValueHolderFactory extends AbstractBaseFactory
      *   array<string, mixed>=,
      *   ?Closure=
      * ) : bool $initializer
+     * @psalm-param array{fluentSafe?: bool} $proxyOptions
      *
      * @psalm-return RealObjectType&ValueHolderInterface<RealObjectType>&VirtualProxyInterface
      *

--- a/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
+++ b/src/ProxyManager/ProxyGenerator/LazyLoadingValueHolderGenerator.php
@@ -37,6 +37,10 @@ use ReflectionMethod;
 
 use function array_map;
 use function array_merge;
+use function func_get_arg;
+use function func_num_args;
+use function str_replace;
+use function substr;
 
 /**
  * Generator for proxies implementing {@see \ProxyManager\Proxy\VirtualProxyInterface}
@@ -52,9 +56,14 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
      *
      * @throws InvalidProxiedClassException
      * @throws InvalidArgumentException
+     *
+     * @psalm-param array{fluentSafe?: bool} $proxyOptions
      */
-    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator)
+    public function generate(ReflectionClass $originalClass, ClassGenerator $classGenerator/*, array $proxyOptions = []*/)
     {
+        /** @psalm-var array{fluentSafe?: bool} $proxyOptions */
+        $proxyOptions = func_num_args() >= 3 ? func_get_arg(2) : [];
+
         CanProxyAssertion::assertClassCanBeProxied($originalClass);
 
         $interfaces       = [VirtualProxyInterface::class];
@@ -77,7 +86,7 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
             },
             array_merge(
                 array_map(
-                    $this->buildLazyLoadingMethodInterceptor($initializer, $valueHolder),
+                    $this->buildLazyLoadingMethodInterceptor($initializer, $valueHolder, $proxyOptions['fluentSafe'] ?? false),
                     ProxiedMethodsFilter::getProxiedMethods($originalClass)
                 ),
                 [
@@ -102,14 +111,33 @@ class LazyLoadingValueHolderGenerator implements ProxyGeneratorInterface
 
     private function buildLazyLoadingMethodInterceptor(
         InitializerProperty $initializer,
-        ValueHolderProperty $valueHolder
+        ValueHolderProperty $valueHolder,
+        bool $fluentSafe
     ): callable {
-        return static function (ReflectionMethod $method) use ($initializer, $valueHolder): LazyLoadingMethodInterceptor {
-            return LazyLoadingMethodInterceptor::generateMethod(
+        return static function (ReflectionMethod $method) use ($initializer, $valueHolder, $fluentSafe): LazyLoadingMethodInterceptor {
+            $byRef  = $method->returnsReference() ? '& ' : '';
+            $method = LazyLoadingMethodInterceptor::generateMethod(
                 new MethodReflection($method->getDeclaringClass()->getName(), $method->getName()),
                 $initializer,
                 $valueHolder
             );
+
+            if ($fluentSafe) {
+                $valueHolderName = '$this->' . $valueHolder->getName();
+                $body            = $method->getBody();
+                $newBody         = str_replace('return ' . $valueHolderName, 'if (' . $valueHolderName . ' === $returnValue = ' . $byRef . $valueHolderName, $body);
+
+                if ($newBody !== $body) {
+                    $method->setBody(
+                        substr($newBody, 0, -1) . ') {' . "\n"
+                        . '    return $this;' . "\n"
+                        . '}' . "\n\n"
+                        . 'return $returnValue;'
+                    );
+                }
+            }
+
+            return $method;
         };
     }
 }

--- a/tests/language-feature-scripts/lazy-loading-value-holder-fluent-safe.phpt
+++ b/tests/language-feature-scripts/lazy-loading-value-holder-fluent-safe.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Verifies that generated lazy loading value holders can be fluent-safe
+--FILE--
+<?php
+
+require_once __DIR__ . '/init.php';
+
+class FluentClass
+{
+    public function foo()
+    {
+        return $this;
+    }
+}
+
+$fluentObject = new FluentClass();
+
+$factory = new \ProxyManager\Factory\LazyLoadingValueHolderFactory($configuration);
+
+$init = function (& $wrapped, $proxy, $method, $parameters, & $initializer) use ($fluentObject) {
+    $wrapped = $fluentObject;
+    $initializer = null;
+};
+
+$proxy = $factory->createProxy(FluentClass::class, $init, ['fluentSafe' => true]);
+echo $proxy->foo() === $proxy;
+
+$proxy = $factory->createProxy(FluentClass::class, $init);
+echo $proxy->foo() === $fluentObject;
+?>
+--EXPECT--
+11


### PR DESCRIPTION
I propose to add a "fluentSafe" option to lazy value holders, to have them return the proxy object instead of the value holder when fluent methods are found.

This would be nice to use with interface-based lazy proxies where the proxy is used as a "condom" to prevent access to methods that are on the implementation but not on the proxied interface.