### PR TITLE
#646 #632 #645 only variables should be returned by-ref in generated dynamic property access simulation code

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -10,6 +10,6 @@
             "branch": "master"
         }
     },
-    "minMsi": 84.3,
+    "minMsi": 84.5,
     "minCoveredMsi": 86
 }

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGet.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicGet.php
@@ -39,7 +39,7 @@ class MagicGet extends MagicMethodGenerator
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
             PublicScopeSimulator::OPERATION_GET,
             'name',
-            'value',
+            null,
             $valueHolder,
             'returnValue',
             $originalClass

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIsset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicIsset.php
@@ -39,7 +39,7 @@ class MagicIsset extends MagicMethodGenerator
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
             PublicScopeSimulator::OPERATION_ISSET,
             'name',
-            'value',
+            null,
             $valueHolder,
             'returnValue',
             $originalClass

--- a/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnset.php
+++ b/src/ProxyManager/ProxyGenerator/AccessInterceptorValueHolder/MethodGenerator/MagicUnset.php
@@ -39,7 +39,7 @@ class MagicUnset extends MagicMethodGenerator
         $callParent = PublicScopeSimulator::getPublicAccessSimulationCode(
             PublicScopeSimulator::OPERATION_UNSET,
             'name',
-            'value',
+            null,
             $valueHolder,
             'returnValue',
             $originalClass

--- a/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
@@ -59,12 +59,14 @@ class PublicScopeSimulator
             ? 'new \\ReflectionClass(get_parent_class($this))'
             : 'new \\ReflectionClass(' . var_export($originalClass->getName(), true) . ')';
 
+        $returnPropertyName = $returnPropertyName
+            ?? ($operationType === self::OPERATION_UNSET ? 'unset' : $returnPropertyName);
+
         return '$realInstanceReflection = ' . $originalClassReflection . ';' . "\n\n"
             . 'if (! $realInstanceReflection->hasProperty($' . $nameParameter . ')) {' . "\n"
             . '    $targetObject = ' . $target . ';' . "\n\n"
             . self::getUndefinedPropertyNotice($operationType, $nameParameter)
             . '    ' . self::getOperation($operationType, $nameParameter, $valueParameter) . "\n"
-            . "    return;\n"
             . '}' . "\n\n"
             . '$targetObject = ' . self::getTargetObject($valueHolder) . ";\n"
             . '$accessor = function ' . $byRef . '() use ($targetObject, $' . $nameParameter . $value . ') {' . "\n"
@@ -144,7 +146,9 @@ class PublicScopeSimulator
                 return 'return isset($targetObject->$' . $nameParameter . ');';
 
             case self::OPERATION_UNSET:
-                return 'unset($targetObject->$' . $nameParameter . ');';
+                return 'unset($targetObject->$' . $nameParameter . ');'
+                    . "\n\n"
+                    . '    return;';
         }
 
         throw new InvalidArgumentException(sprintf('Invalid operation "%s" provided', $operationType));

--- a/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
@@ -48,7 +48,7 @@ class PublicScopeSimulator
         ?ReflectionClass $originalClass = null
     ): string {
         $byRef  = self::getByRefReturnValue($operationType);
-        $value  = $operationType === self::OPERATION_SET ? ', $value' : '';
+        $value  = $operationType === self::OPERATION_SET ? ', $' . ($valueParameter ?? 'value') : '';
         $target = '$this';
 
         if ($valueHolder) {
@@ -67,7 +67,7 @@ class PublicScopeSimulator
             . "    return;\n"
             . '}' . "\n\n"
             . '$targetObject = ' . self::getTargetObject($valueHolder) . ";\n"
-            . '$accessor = function ' . $byRef . '() use ($targetObject, $name' . $value . ') {' . "\n"
+            . '$accessor = function ' . $byRef . '() use ($targetObject, $' . $nameParameter . $value . ') {' . "\n"
             . '    ' . self::getOperation($operationType, $nameParameter, $valueParameter) . "\n"
             . "};\n"
             . self::getScopeReBind()
@@ -138,7 +138,7 @@ class PublicScopeSimulator
                     throw new InvalidArgumentException('Parameter $valueParameter not provided');
                 }
 
-                return 'return $targetObject->$' . $nameParameter . ' = $' . $valueParameter . ';';
+                return '$targetObject->$' . $nameParameter . ' = $' . $valueParameter . '; return $targetObject->$' . $nameParameter . ';';
 
             case self::OPERATION_ISSET:
                 return 'return isset($targetObject->$' . $nameParameter . ');';

--- a/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
@@ -8,6 +8,9 @@ use InvalidArgumentException;
 use Laminas\Code\Generator\PropertyGenerator;
 use ReflectionClass;
 
+use function array_filter;
+use function array_map;
+use function implode;
 use function sprintf;
 use function var_export;
 
@@ -30,7 +33,8 @@ class PublicScopeSimulator
      *
      * @param string            $operationType      operation to execute: one of 'get', 'set', 'isset' or 'unset'
      * @param string            $nameParameter      name of the `name` parameter of the magic method
-     * @param string|null       $valueParameter     name of the `value` parameter of the magic method
+     * @param string|null       $valueParameter     name of the `value` parameter of the magic method, only to be
+     *                                              used with $operationType 'set'
      * @param PropertyGenerator $valueHolder        name of the property containing the target object from which
      *                                              to read the property. `$this` if none provided
      * @param string|null       $returnPropertyName name of the property to which we want to assign the result of
@@ -50,7 +54,6 @@ class PublicScopeSimulator
         ?ReflectionClass $originalClass = null
     ): string {
         $byRef  = self::getByRefReturnValue($operationType);
-        $value  = $operationType === self::OPERATION_SET ? ', $' . ($valueParameter ?? 'value') : '';
         $target = '$this';
 
         if ($valueHolder) {
@@ -61,7 +64,13 @@ class PublicScopeSimulator
             ? 'new \\ReflectionClass(get_parent_class($this))'
             : 'new \\ReflectionClass(' . var_export($originalClass->getName(), true) . ')';
 
-        $returnPropertyName ??= ($operationType === self::OPERATION_UNSET ? 'unset' : $returnPropertyName);
+        $accessorEvaluation = $returnPropertyName
+            ? '$' . $returnPropertyName . ' = ' . $byRef . '$accessor();'
+            : '$returnValue = ' . $byRef . '$accessor();' . "\n\n" . 'return $returnValue;';
+
+        if ($operationType === self::OPERATION_UNSET) {
+            $accessorEvaluation = '$accessor();';
+        }
 
         return '$realInstanceReflection = ' . $originalClassReflection . ';' . "\n\n"
             . 'if (! $realInstanceReflection->hasProperty($' . $nameParameter . ')) {' . "\n"
@@ -70,19 +79,22 @@ class PublicScopeSimulator
             . '    ' . self::getOperation($operationType, $nameParameter, $valueParameter) . "\n"
             . '}' . "\n\n"
             . '$targetObject = ' . self::getTargetObject($valueHolder) . ";\n"
-            . '$accessor = function ' . $byRef . '() use ($targetObject, $' . $nameParameter . $value . ') {' . "\n"
+            . '$accessor = function ' . $byRef . '() use ('
+            . implode(', ', array_map(
+                static fn (string $parameterName): string => '$' . $parameterName,
+                array_filter(['targetObject', $nameParameter, $valueParameter])
+            ))
+            . ') {' . "\n"
             . '    ' . self::getOperation($operationType, $nameParameter, $valueParameter) . "\n"
             . "};\n"
-            . self::getScopeReBind()
-            . (
-                $returnPropertyName
-                    ? '$' . $returnPropertyName . ' = ' . $byRef . '$accessor();'
-                    : '$returnValue = ' . $byRef . '$accessor();' . "\n\n" . 'return $returnValue;'
-            );
+            . self::generateScopeReBind()
+            . $accessorEvaluation;
     }
 
     /**
      * This will generate code that triggers a notice if access is attempted on a non-existing property
+     *
+     * @psalm-param $operationType self::OPERATION_*
      */
     private static function getUndefinedPropertyNotice(string $operationType, string $nameParameter): string
     {
@@ -109,6 +121,8 @@ class PublicScopeSimulator
      * Note: if the object is a wrapper, the wrapped instance is accessed directly. If the object
      * is a ghost or the proxy has no wrapper, then an instance of the parent class is created via
      * on-the-fly unserialization
+     *
+     * @psalm-param $operationType self::OPERATION_*
      */
     private static function getByRefReturnValue(string $operationType): string
     {
@@ -129,19 +143,35 @@ class PublicScopeSimulator
 
     /**
      * @throws InvalidArgumentException
+     *
+     * @psalm-param $operationType self::OPERATION_*
      */
     private static function getOperation(string $operationType, string $nameParameter, ?string $valueParameter): string
     {
+        if ($valueParameter !== null && $operationType !== self::OPERATION_SET) {
+            throw new InvalidArgumentException(
+                'Parameter $valueParameter should be provided (only) when $operationType === "' . self::OPERATION_SET . '"'
+                . self::class
+                . '::OPERATION_SET'
+            );
+        }
+
         switch ($operationType) {
             case self::OPERATION_GET:
                 return 'return $targetObject->$' . $nameParameter . ';';
 
             case self::OPERATION_SET:
                 if ($valueParameter === null) {
-                    throw new InvalidArgumentException('Parameter $valueParameter not provided');
+                    throw new InvalidArgumentException(
+                        'Parameter $valueParameter should be provided (only) when $operationType === "' . self::OPERATION_SET . '"'
+                        . self::class
+                        . '::OPERATION_SET'
+                    );
                 }
 
-                return '$targetObject->$' . $nameParameter . ' = $' . $valueParameter . '; return $targetObject->$' . $nameParameter . ';';
+                return '$targetObject->$' . $nameParameter . ' = $' . $valueParameter . ';'
+                    . "\n\n"
+                    . '    return $targetObject->$' . $nameParameter . ';';
 
             case self::OPERATION_ISSET:
                 return 'return isset($targetObject->$' . $nameParameter . ');';
@@ -158,11 +188,13 @@ class PublicScopeSimulator
     /**
      * Generates code to bind operations to the parent scope
      */
-    private static function getScopeReBind(): string
+    private static function generateScopeReBind(): string
     {
-        return '$backtrace = debug_backtrace(true, 2);' . "\n"
-            . '$scopeObject = isset($backtrace[1][\'object\'])'
-            . ' ? $backtrace[1][\'object\'] : new \ProxyManager\Stub\EmptyClassStub();' . "\n"
-            . '$accessor = $accessor->bindTo($scopeObject, get_class($scopeObject));' . "\n";
+        return <<<'PHP'
+$backtrace = debug_backtrace(true, 2);
+$scopeObject = isset($backtrace[1]['object']) ? $backtrace[1]['object'] : new \ProxyManager\Stub\EmptyClassStub();
+$accessor = $accessor->bindTo($scopeObject, get_class($scopeObject));
+
+PHP;
     }
 }

--- a/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
@@ -37,9 +37,9 @@ class PublicScopeSimulator
      *                                              the operation. Return directly if none provided
      * @param string|null       $interfaceName      name of the proxified interface if any
      *
-     * @psalm-param $operationType self::OPERATION_*
-     *
      * @throws InvalidArgumentException
+     *
+     * @psalm-param $operationType self::OPERATION_*
      */
     public static function getPublicAccessSimulationCode(
         string $operationType,
@@ -61,8 +61,7 @@ class PublicScopeSimulator
             ? 'new \\ReflectionClass(get_parent_class($this))'
             : 'new \\ReflectionClass(' . var_export($originalClass->getName(), true) . ')';
 
-        $returnPropertyName = $returnPropertyName
-            ?? ($operationType === self::OPERATION_UNSET ? 'unset' : $returnPropertyName);
+        $returnPropertyName ??= ($operationType === self::OPERATION_UNSET ? 'unset' : $returnPropertyName);
 
         return '$realInstanceReflection = ' . $originalClassReflection . ';' . "\n\n"
             . 'if (! $realInstanceReflection->hasProperty($' . $nameParameter . ')) {' . "\n"

--- a/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
+++ b/src/ProxyManager/ProxyGenerator/Util/PublicScopeSimulator.php
@@ -37,6 +37,8 @@ class PublicScopeSimulator
      *                                              the operation. Return directly if none provided
      * @param string|null       $interfaceName      name of the proxified interface if any
      *
+     * @psalm-param $operationType self::OPERATION_*
+     *
      * @throws InvalidArgumentException
      */
     public static function getPublicAccessSimulationCode(

--- a/tests/ProxyManagerTest/Functional/PublicScopeSimulatorFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/PublicScopeSimulatorFunctionalTest.php
@@ -25,7 +25,7 @@ final class PublicScopeSimulatorFunctionalTest extends TestCase
     {
         /** @psalm-var ClassWithMixedProperties $sut */
         $sut = eval(sprintf(
-<<<'PHP'
+            <<<'PHP'
 return new class() extends %s {
     public function doGet($prop) : string { %s }
     public function doSet($prop, $val) : string { %s }
@@ -33,7 +33,7 @@ return new class() extends %s {
     public function doUnset($prop) : void { %s }
 };
 PHP
-                ,
+            ,
             ClassWithMixedProperties::class,
             PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_GET, 'prop'),
             PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_SET, 'prop', 'val'),

--- a/tests/ProxyManagerTest/Functional/PublicScopeSimulatorFunctionalTest.php
+++ b/tests/ProxyManagerTest/Functional/PublicScopeSimulatorFunctionalTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTest\ProxyGenerator\Functional;
+
+use PHPUnit\Framework\TestCase;
+use ProxyManager\ProxyGenerator\Util\PublicScopeSimulator;
+use ProxyManagerTestAsset\ClassWithMixedProperties;
+
+use function sprintf;
+
+/**
+ * @covers \ProxyManager\ProxyGenerator\Util\PublicScopeSimulator
+ * @coversNothing
+ */
+final class PublicScopeSimulatorFunctionalTest extends TestCase
+{
+    /**
+     * @group #632
+     * @group #645
+     * @group #646
+     */
+    public function testAccessingUndefinedPropertiesDoesNotLeadToInvalidByRefAccess(): void
+    {
+        /** @psalm-var ClassWithMixedProperties $sut */
+        $sut = eval(sprintf(
+<<<'PHP'
+return new class() extends %s {
+    public function doGet($prop) : string { %s }
+    public function doSet($prop, $val) : string { %s }
+    public function doIsset($prop) : bool { %s }
+    public function doUnset($prop) : void { %s }
+};
+PHP
+                ,
+            ClassWithMixedProperties::class,
+            PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_GET, 'prop'),
+            PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_SET, 'prop', 'val'),
+            PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_ISSET, 'prop'),
+            PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_UNSET, 'prop')
+        ));
+
+        self::assertSame('publicProperty0', $sut->doGet('publicProperty0'));
+        self::assertSame('bar', $sut->doSet('publicProperty0', 'bar'));
+        self::assertTrue($sut->doIsset('publicProperty0'));
+        self::assertNull($sut->doUnset('publicProperty0'));
+    }
+}

--- a/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/AccessInterceptorScopeLocalizer/MethodGenerator/MagicUnsetTest.php
@@ -39,7 +39,7 @@ final class MagicUnsetTest extends TestCase
 
         self::assertSame('__unset', $magicGet->getName());
         self::assertCount(1, $magicGet->getParameters());
-        self::assertStringMatchesFormat('%a$returnValue = $accessor();%a', $magicGet->getBody());
+        self::assertStringMatchesFormat('%a$accessor();%a', $magicGet->getBody());
     }
 
     /**

--- a/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnsetTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/LazyLoadingValueHolder/MethodGenerator/MagicUnsetTest.php
@@ -41,7 +41,7 @@ final class MagicUnsetTest extends TestCase
             "\$this->foo && \$this->foo->__invoke(\$this->bar, \$this, '__unset', array('name' => \$name)"
             . ", \$this->foo);\n\n"
             . "if (isset(self::\$bar[\$name])) {\n    unset(\$this->bar->\$name);\n\n    return;\n}"
-            . '%areturn %s;',
+            . '%a',
             $magicIsset->getBody()
         );
     }

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
@@ -42,7 +42,6 @@ if (! $realInstanceReflection->hasProperty($foo)) {
         \E_USER_NOTICE
     );
     return $targetObject->$foo;
-    return;
 }
 
 $targetObject = $realInstanceReflection->newInstanceWithoutConstructor();
@@ -76,7 +75,6 @@ if (! $realInstanceReflection->hasProperty($foo)) {
     $targetObject = $this;
 
     $targetObject->$foo = $baz; return $targetObject->$foo;
-    return;
 }
 
 $targetObject = $realInstanceReflection->newInstanceWithoutConstructor();
@@ -110,7 +108,6 @@ if (! $realInstanceReflection->hasProperty($foo)) {
     $targetObject = $this;
 
     return isset($targetObject->$foo);
-    return;
 }
 
 $targetObject = $realInstanceReflection->newInstanceWithoutConstructor();
@@ -144,12 +141,15 @@ if (! $realInstanceReflection->hasProperty($foo)) {
     $targetObject = $this;
 
     unset($targetObject->$foo);
+
     return;
 }
 
 $targetObject = $realInstanceReflection->newInstanceWithoutConstructor();
 $accessor = function () use ($targetObject, $foo) {
     unset($targetObject->$foo);
+
+    return;
 };
 $backtrace = debug_backtrace(true, 2);
 $scopeObject = isset($backtrace[1]['object']) ? $backtrace[1]['object'] : new \ProxyManager\Stub\EmptyClassStub();
@@ -165,6 +165,22 @@ PHP;
                 null,
                 null,
                 'bar'
+            )
+        );
+    }
+
+    /**
+     * @group #632
+     * @group #645
+     * @group #646
+     */
+    public function testUnsetCodeWillNotProduceReturnValueStatements(): void
+    {
+        self::assertStringNotContainsString(
+            'return ',
+            PublicScopeSimulator::getPublicAccessSimulationCode(
+                PublicScopeSimulator::OPERATION_UNSET,
+                'foo'
             )
         );
     }
@@ -191,7 +207,6 @@ if (! $realInstanceReflection->hasProperty($foo)) {
     $targetObject = $this->valueHolder;
 
     $targetObject->$foo = $baz; return $targetObject->$foo;
-    return;
 }
 
 $targetObject = $this->valueHolder;
@@ -243,7 +258,6 @@ if (! $realInstanceReflection->hasProperty($foo)) {
         \E_USER_NOTICE
     );
     return $targetObject->$foo;
-    return;
 }
 
 $targetObject = $realInstanceReflection->newInstanceWithoutConstructor();

--- a/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/Util/PublicScopeSimulatorTest.php
@@ -299,35 +299,4 @@ PHP
             )
         );
     }
-
-    /**
-     * @group #632
-     * @group #645
-     * @group #646
-     */
-    public function testFunctional(): void
-    {
-        /** @psalm-var ClassWithMixedProperties $sut */
-        $sut = eval(
-            sprintf(
-                'return new class() extends %s
-                {
-                    public function doGet($prop) { %s }
-                    public function doSet($prop, $val) { %s }
-                    public function doIsset($prop) { %s }
-                    public function doUnset($prop) { %s }
-                };',
-                ClassWithMixedProperties::class,
-                PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_GET, 'prop'),
-                PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_SET, 'prop', 'val'),
-                PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_ISSET, 'prop'),
-                PublicScopeSimulator::getPublicAccessSimulationCode(PublicScopeSimulator::OPERATION_UNSET, 'prop')
-            )
-        );
-
-        $this->assertSame('publicProperty0', $sut->doGet('publicProperty0'));
-        $this->assertSame('bar', $sut->doSet('publicProperty0', 'bar'));
-        $this->assertTrue($sut->doIsset('publicProperty0'));
-        $this->assertNull($sut->doUnset('publicProperty0'));
-    }
 }


### PR DESCRIPTION
Fixes #632 
Fixes #645
Fixes #646 