### PR TITLE
Various small documentation cleanups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ title: Contributing
  * The project will follow strict [object calisthenics](http://www.slideshare.net/guilhermeblanco/object-calisthenics-applied-to-php)
  * Any contribution must provide tests for additional introduced conditions
  * Any un-confirmed issue needs a failing test case before being accepted
- * Pull requests must be sent from a new hotfix/feature branch, not from `master`.
+ * Pull requests must be sent from a new hotfix/feature branch
 
 ## Installation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,11 @@ To install the project and run the tests, you need to clone it first:
 $ git clone git://github.com/Ocramius/ProxyManager.git
 ```
 
-You will then need to run a composer installation:
+Make sure you've [installed Composer](https://getcomposer.org/download/) and install the dependencies:
 
 ```sh
 $ cd ProxyManager
-$ curl -s https://getcomposer.org/installer | php
-$ php composer.phar update
+$ composer update
 ```
 
 ## Testing
@@ -35,4 +34,3 @@ $ ./vendor/bin/phpunit
 ```
 
 Accepted coverage for new contributions is 80%. Any contribution not satisfying this requirement won't be merged.
-

--- a/docs/access-interceptor-scope-localizer.md
+++ b/docs/access-interceptor-scope-localizer.md
@@ -1,7 +1,3 @@
----
-title: Access Interceptor Scope Localizer Proxy
----
-
 # Access Interceptor Scope Localizer Proxy
 
 An access interceptor scope localizer is a smart reference proxy that allows you to dynamically define logic to be executed 

--- a/docs/access-interceptor-value-holder.md
+++ b/docs/access-interceptor-value-holder.md
@@ -1,7 +1,3 @@
----
-title: Access Interceptor Value Holder Proxy
----
-
 # Access Interceptor Value Holder Proxy
 
 An *access interceptor value holder* is a smart reference proxy that allows you to dynamically define the logic that will be executed before or after any of the wrapped object's methods logic.

--- a/docs/copyright.md
+++ b/docs/copyright.md
@@ -1,7 +1,3 @@
----
-title: License
----
-
 # License
 
 Copyright (c) 2013 Marco Pivetta
@@ -11,5 +7,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -1,13 +1,7 @@
----
-title: Credits
----
-
 # Credits
 
 The idea was originated by a [talk about Proxies in PHP OOP](https://ocramius.github.io/presentations/proxy-pattern-in-php/) that I gave at 
 the [@phpugffm](https://twitter.com/phpugffm) in January 2013.
-
----
 
 ### Contributors
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,11 +1,7 @@
----
-title: Download / Installation
----
-
 ## Download / Installation
 
-The suggested installation method is via [composer](https://getcomposer.org/).
+The suggested installation method is via [Composer](https://getcomposer.org/):
 
 ```sh
-php composer.phar require ocramius/proxy-manager:1.0.*
+composer require ocramius/proxy-manager
 ```

--- a/docs/generator-strategies.md
+++ b/docs/generator-strategies.md
@@ -1,7 +1,3 @@
----
-title: Generator strategies
----
-
 # Generator strategies
 
 ProxyManager allows you to generate classes based on generator strategies and a given `Laminas\Code\Generator\ClassGenerator` as of the [interface of a generator strategy](https://github.com/Ocramius/ProxyManager/blob/master/src/ProxyManager/GeneratorStrategy/GeneratorStrategyInterface.php).

--- a/docs/lazy-loading-ghost-object.md
+++ b/docs/lazy-loading-ghost-object.md
@@ -1,7 +1,3 @@
----
-title: Lazy Loading Ghost Object Proxies
----
-
 # Lazy Loading Ghost Object Proxies
 
 A Lazy Loading Ghost is a type of proxy object.

--- a/docs/lazy-loading-value-holder.md
+++ b/docs/lazy-loading-value-holder.md
@@ -1,7 +1,3 @@
----
-title: Lazy Loading Value Holder Proxy
----
-
 # Lazy Loading Value Holder Proxy
 
 A lazy loading value holder proxy is a virtual proxy that wraps and lazily initializes a "real" instance of the proxied class.

--- a/docs/null-object.md
+++ b/docs/null-object.md
@@ -1,7 +1,3 @@
----
-title: Null Object Proxy
----
-
 # Null Object Proxy
 
 A Null Object proxy is a [null object pattern](http://en.wikipedia.org/wiki/Null_Object_pattern) implementation.

--- a/docs/remote-object.md
+++ b/docs/remote-object.md
@@ -1,7 +1,3 @@
----
-title: Remote Object Proxy
----
-
 # Remote Object Proxy
 
 The remote object implementation is a mechanism that enables a local object to control another object on another server. Each 

--- a/docs/tuning-for-production.md
+++ b/docs/tuning-for-production.md
@@ -1,8 +1,4 @@
----
-title: Tuning the ProxyManager for production
----
-
-## Tuning the ProxyManager for production
+# Tuning the ProxyManager for production
 
 By default, all proxy factories generate the required proxy classes at runtime.
 


### PR DESCRIPTION
I've grouped each change by commit, I think the commits are quite self-explanatory.

As a first-time reader of this docs, I also think it's good to order the docs (e.g. by numbering the file names or having an `index.md` file). I'm however not the correct person to decide the order of the docs :) (I can only see that "download.md" is probably first).

---

Btw, I've left the links to classes with `master` intact. GitHub automatically redirects those to the default branch - which I think is perfect for these links.