### PR TITLE
Remove redundant error handler in generate

### DIFF
--- a/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
+++ b/src/ProxyManager/GeneratorStrategy/FileWriterGeneratorStrategy.php
@@ -4,15 +4,11 @@ declare(strict_types=1);
 
 namespace ProxyManager\GeneratorStrategy;
 
-use Closure;
 use Laminas\Code\Generator\ClassGenerator;
 use ProxyManager\Exception\FileNotWritableException;
 use ProxyManager\FileLocator\FileLocatorInterface;
 use Webimpress\SafeWriter\Exception\ExceptionInterface as FileWriterException;
 use Webimpress\SafeWriter\FileWriter;
-
-use function restore_error_handler;
-use function set_error_handler;
 
 /**
  * Generator strategy that writes the generated classes to disk while generating them
@@ -22,13 +18,10 @@ use function set_error_handler;
 class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
 {
     protected FileLocatorInterface $fileLocator;
-    private Closure $emptyErrorHandler;
 
     public function __construct(FileLocatorInterface $fileLocator)
     {
-        $this->fileLocator       = $fileLocator;
-        $this->emptyErrorHandler = static function (): void {
-        };
+        $this->fileLocator = $fileLocator;
     }
 
     /**
@@ -44,16 +37,12 @@ class FileWriterGeneratorStrategy implements GeneratorStrategyInterface
         $className     = $classGenerator->getNamespaceName() . '\\' . $classGenerator->getName();
         $fileName      = $this->fileLocator->getProxyFileName($className);
 
-        set_error_handler($this->emptyErrorHandler);
-
         try {
             FileWriter::writeFile($fileName, "<?php\n\n" . $generatedCode);
 
             return $generatedCode;
         } catch (FileWriterException $e) {
             throw FileNotWritableException::fromPrevious($e);
-        } finally {
-            restore_error_handler();
         }
     }
 }

--- a/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
+++ b/tests/ProxyManagerTest/GeneratorStrategy/FileWriterGeneratorStrategyTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace ProxyManagerTest\GeneratorStrategy;
 
-use Closure;
-use ErrorException;
 use Laminas\Code\Generator\ClassGenerator;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Exception\FileNotWritableException;
@@ -18,10 +16,8 @@ use function clearstatcache;
 use function decoct;
 use function fileperms;
 use function mkdir;
-use function restore_error_handler;
 use function rmdir;
 use function scandir;
-use function set_error_handler;
 use function strpos;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -42,31 +38,15 @@ use const SCANDIR_SORT_ASCENDING;
 final class FileWriterGeneratorStrategyTest extends TestCase
 {
     private string $tempDir;
-    private Closure $originalErrorHandler;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->tempDir              = tempnam(sys_get_temp_dir(), 'FileWriterGeneratorStrategyTest');
-        $this->originalErrorHandler = static function (): bool {
-            throw new ErrorException();
-        };
+        $this->tempDir = tempnam(sys_get_temp_dir(), 'FileWriterGeneratorStrategyTest');
 
         unlink($this->tempDir);
         mkdir($this->tempDir);
-        set_error_handler($this->originalErrorHandler);
-    }
-
-    protected function tearDown(): void
-    {
-        self::assertSame($this->originalErrorHandler, set_error_handler(static function (): bool {
-            return true;
-        }));
-        restore_error_handler();
-        restore_error_handler();
-
-        parent::tearDown();
     }
 
     public function testGenerate(): void


### PR DESCRIPTION
Relates to webimpress/safe-writer#49

The problem is with testing in ocramius/proxy-manager, not in safe-writer itself.

Update: still it can be improved in safe-writer to set custom error-handler instead of suppressing warnings with `@`.