### PR TITLE
Make library compatible with `composer/composer:^2.0.14`, do not call `InstalledVersions::getRawData()` (which introduces runtime side-effect in pure API)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "webimpress/safe-writer":    "^2.2.0"
     },
     "conflict": {
+        "composer/composer":         "<2.0.14",
         "zendframework/zend-stdlib": "<3.2.1",
         "laminas/laminas-stdlib":    "<3.2.1",
         "doctrine/annotations":      "<1.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c17c70d4578784a835b559dbec85ee2",
+    "content-hash": "5484b8fe6ef7e0842e08bc8b58bb3f5c",
     "packages": [
         {
             "name": "laminas/laminas-code",

--- a/src/ProxyManager/Generator/Util/IdentifierSuffixer.php
+++ b/src/ProxyManager/Generator/Util/IdentifierSuffixer.php
@@ -6,7 +6,6 @@ namespace ProxyManager\Generator\Util;
 
 use Composer\InstalledVersions;
 
-use function is_callable;
 use function preg_match;
 use function serialize;
 use function sha1;
@@ -49,10 +48,6 @@ abstract class IdentifierSuffixer
 
     private static function loadBaseHashSalt(): string
     {
-        return sha1(serialize(
-            is_callable([InstalledVersions::class, 'getAllRawData'])
-                ? InstalledVersions::getAllRawData() // Composer >= 2.0.14
-                : InstalledVersions::getRawData()
-        ));
+        return sha1(serialize(InstalledVersions::getAllRawData()));
     }
 }

--- a/src/ProxyManager/Generator/Util/IdentifierSuffixer.php
+++ b/src/ProxyManager/Generator/Util/IdentifierSuffixer.php
@@ -6,6 +6,7 @@ namespace ProxyManager\Generator\Util;
 
 use Composer\InstalledVersions;
 
+use function is_callable;
 use function preg_match;
 use function serialize;
 use function sha1;
@@ -48,6 +49,10 @@ abstract class IdentifierSuffixer
 
     private static function loadBaseHashSalt(): string
     {
-        return sha1(serialize(InstalledVersions::getRawData()));
+        return sha1(serialize(
+            is_callable([InstalledVersions::class, 'getAllRawData'])
+                ? InstalledVersions::getAllRawData() // Composer >= 2.0.14
+                : InstalledVersions::getRawData()
+        ));
     }
 }

--- a/tests/ProxyManagerTest/Generator/Util/IdentifierSuffixerTest.php
+++ b/tests/ProxyManagerTest/Generator/Util/IdentifierSuffixerTest.php
@@ -8,6 +8,7 @@ use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Generator\Util\IdentifierSuffixer;
 
+use function is_callable;
 use function serialize;
 use function sha1;
 use function strlen;
@@ -37,8 +38,14 @@ final class IdentifierSuffixerTest extends TestCase
      */
     public function testGeneratedSuffixDependsOnPackageInstalledVersions(string $name): void
     {
+        $hashedData = sha1(serialize(
+            is_callable([InstalledVersions::class, 'getAllRawData'])
+                ? InstalledVersions::getAllRawData()
+                : InstalledVersions::getRawData()
+        ));
+
         self::assertStringEndsWith(
-            substr(sha1($name . sha1(serialize(InstalledVersions::getRawData()))), 0, 5),
+            substr(sha1($name . $hashedData), 0, 5),
             IdentifierSuffixer::getIdentifier($name)
         );
     }


### PR DESCRIPTION
Follows composer/composer#9816

This PR proposes to not call `InstalledVersions::getRawData()` anymore. This method has been deprecated and triggers runtime deprecation warnings since Composer 2.0.14.