### PR TITLE
Upgraded to `composer-runtime-api:^2.1.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,10 @@
     "require": {
         "php":                       "~7.4.1 || ~8.0.0",
         "laminas/laminas-code":      "^4.3.0",
-        "composer-runtime-api":      "^2.0.0",
+        "composer-runtime-api":      "^2.1.0",
         "webimpress/safe-writer":    "^2.2.0"
     },
     "conflict": {
-        "composer/composer":         "<2.0.14",
         "zendframework/zend-stdlib": "<3.2.1",
         "laminas/laminas-stdlib":    "<3.2.1",
         "doctrine/annotations":      "<1.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5484b8fe6ef7e0842e08bc8b58bb3f5c",
+    "content-hash": "a6661f437d891557f508ffd91a6913bf",
     "packages": [
         {
             "name": "laminas/laminas-code",
@@ -6053,10 +6053,10 @@
     "prefer-lowest": false,
     "platform": {
         "php": "~7.4.1 || ~8.0.0",
-        "composer-runtime-api": "^2.0.0"
+        "composer-runtime-api": "^2.1.0"
     },
     "platform-dev": {
         "ext-phar": "*"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/ProxyManager/Version.php
+++ b/src/ProxyManager/Version.php
@@ -34,7 +34,7 @@ final class Version
      */
     public static function getVersion(): string
     {
-        return InstalledVersions::getPrettyVersion('ocramius/proxy-manager')
-            . '@' . InstalledVersions::getReference('ocramius/proxy-manager');
+        return (string) InstalledVersions::getPrettyVersion('ocramius/proxy-manager')
+            . '@' . (string) InstalledVersions::getReference('ocramius/proxy-manager');
     }
 }


### PR DESCRIPTION
`composer-runtime-api:2.0.x` included deprecations that caused crashes/errors before
`composer/composer:2.0.14`, and a restriction to `"conflict": {"composer/composer": "<2.0.14"}`
did not work ( https://github.com/Ocramius/ProxyManager/pull/700#issuecomment-847830536 ).

In order to clean this up, this fixes #702 by declaring a the dependency to `composer-runtime-api:^2.1.0`
explicitly, effectively excluding `composer/composer:~2.0.0` from installation candiates.