### PR TITLE
Don't call deprecated InstalledVersions::getRawData()

### DIFF
--- a/src/ProxyManager/Generator/Util/IdentifierSuffixer.php
+++ b/src/ProxyManager/Generator/Util/IdentifierSuffixer.php
@@ -6,6 +6,7 @@ namespace ProxyManager\Generator\Util;
 
 use Composer\InstalledVersions;
 
+use function is_callable;
 use function preg_match;
 use function serialize;
 use function sha1;
@@ -48,6 +49,12 @@ abstract class IdentifierSuffixer
 
     private static function loadBaseHashSalt(): string
     {
-        return sha1(serialize(InstalledVersions::getRawData()));
+        $hashedData = sha1(serialize(
+            is_callable([InstalledVersions::class, 'getAllRawData'])
+                ? InstalledVersions::getAllRawData()
+                : InstalledVersions::getRawData()
+        ));
+
+        return sha1(serialize($hashedData));
     }
 }

--- a/tests/ProxyManagerTest/Generator/Util/IdentifierSuffixerTest.php
+++ b/tests/ProxyManagerTest/Generator/Util/IdentifierSuffixerTest.php
@@ -8,6 +8,7 @@ use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\Generator\Util\IdentifierSuffixer;
 
+use function is_callable;
 use function serialize;
 use function sha1;
 use function strlen;
@@ -37,8 +38,14 @@ final class IdentifierSuffixerTest extends TestCase
      */
     public function testGeneratedSuffixDependsOnPackageInstalledVersions(string $name): void
     {
+        $hashedData = sha1(serialize(
+            is_callable([InstalledVersions::class, 'getAllRawData'])
+                ? InstalledVersions::getAllRawData()
+                : InstalledVersions::getRawData()
+        ));
+
         self::assertStringEndsWith(
-            substr(sha1($name . sha1(serialize(InstalledVersions::getRawData()))), 0, 5),
+            substr(sha1($name . sha1(serialize($hashedData))), 0, 5),
             IdentifierSuffixer::getIdentifier($name)
         );
     }


### PR DESCRIPTION
Logs get spammed with an error to not call getRawData() since its depricated.
I used the same fix as the 2.12.x branch instead of updating to it, since it requires PHP 8 and out application is still on 7.4.