### PR TITLE
Honor inherited magic methods' return types when generating decorators

### DIFF
--- a/src/ProxyManager/Generator/MagicMethodGenerator.php
+++ b/src/ProxyManager/Generator/MagicMethodGenerator.php
@@ -5,8 +5,14 @@ declare(strict_types=1);
 namespace ProxyManager\Generator;
 
 use Laminas\Code\Generator\ParameterGenerator;
+use LogicException;
 use ReflectionClass;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionUnionType;
 
+use function get_class;
+use function implode;
 use function strtolower;
 
 /**
@@ -31,6 +37,22 @@ class MagicMethodGenerator extends MethodGenerator
             return;
         }
 
-        $this->setReturnsReference($originalClass->getMethod($name)->returnsReference());
+        $originalMethod     = $originalClass->getMethod($name);
+        $originalReturnType = $originalMethod->getReturnType();
+
+        $this->setReturnsReference($originalMethod->returnsReference());
+
+        if ($originalReturnType instanceof ReflectionNamedType) {
+            $this->setReturnType(($originalReturnType->allowsNull() && $originalReturnType->getName() !== 'mixed' ? '?' : '') . $originalReturnType->getName());
+        } elseif ($originalReturnType instanceof ReflectionUnionType || $originalReturnType instanceof ReflectionIntersectionType) {
+            $returnType = [];
+            foreach ($originalReturnType->getTypes() as $type) {
+                $returnType[] = $type->getName();
+            }
+
+            $this->setReturnType(implode($originalReturnType instanceof ReflectionIntersectionType ? '&' : '|', $returnType));
+        } elseif ($originalReturnType) {
+            throw new LogicException('Unexpected ' . get_class($type));
+        }
     }
 }

--- a/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/NullObjectGeneratorTest.php
@@ -89,7 +89,7 @@ final class NullObjectGeneratorTest extends AbstractProxyGeneratorTest
             $callback = [$proxy, $method->getName()];
 
             self::assertIsCallable($callback);
-            self::assertNull($callback());
+            self::assertEmpty($callback());
         }
     }
 

--- a/tests/ProxyManagerTestAsset/ClassWithMagicMethods.php
+++ b/tests/ProxyManagerTestAsset/ClassWithMagicMethods.php
@@ -17,7 +17,7 @@ class ClassWithMagicMethods
         return [$name => $value];
     }
 
-    public function __get($name)
+    public function __get($name): mixed
     {
         return $name;
     }
@@ -32,7 +32,7 @@ class ClassWithMagicMethods
         return (bool) $name;
     }
 
-    public function __sleep()
+    public function __sleep(): array
     {
         return [];
     }


### PR DESCRIPTION
Backported from https://github.com/FriendsOfPHP/proxy-manager-lts/pull/20

Fix #346