### PR TITLE
Promoted constructor properties should not be doubled, fix #784

### DIFF
--- a/src/ProxyManager/Generator/MethodGenerator.php
+++ b/src/ProxyManager/Generator/MethodGenerator.php
@@ -6,6 +6,7 @@ namespace ProxyManager\Generator;
 
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\MethodGenerator as LaminasMethodGenerator;
+use Laminas\Code\Generator\ParameterGenerator;
 use Laminas\Code\Reflection\MethodReflection;
 
 /**
@@ -19,10 +20,23 @@ class MethodGenerator extends LaminasMethodGenerator
     public static function fromReflectionWithoutBodyAndDocBlock(MethodReflection $reflectionMethod): self
     {
         /** @var static $method */
-        $method = parent::copyMethodSignature($reflectionMethod);
+        $method = static::copyMethodSignature($reflectionMethod);
 
         $method->setInterface(false);
         $method->setBody('');
+
+        return $method;
+    }
+
+    public static function copyMethodSignature(MethodReflection $reflectionMethod): parent
+    {
+        $method = parent::copyMethodSignature($reflectionMethod);
+
+        foreach ($reflectionMethod->getParameters() as $reflectionParameter) {
+            $method->setParameter(
+                ParameterGenerator::fromReflection($reflectionParameter)
+            );
+        }
 
         return $method;
     }

--- a/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/ConstructorTest.php
+++ b/tests/ProxyManagerTest/ProxyGenerator/ValueHolder/MethodGenerator/ConstructorTest.php
@@ -8,6 +8,7 @@ use Laminas\Code\Generator\PropertyGenerator;
 use PHPUnit\Framework\TestCase;
 use ProxyManager\ProxyGenerator\ValueHolder\MethodGenerator\Constructor;
 use ProxyManagerTestAsset\ClassWithMixedProperties;
+use ProxyManagerTestAsset\ClassWithPromotedProperties;
 use ProxyManagerTestAsset\ClassWithVariadicConstructorArgument;
 use ProxyManagerTestAsset\EmptyClass;
 use ProxyManagerTestAsset\ProxyGenerator\LazyLoading\MethodGenerator\ClassWithTwoPublicProperties;
@@ -133,4 +134,23 @@ PHP;
 
         self::assertSame($expectedCode, $constructor->getBody());
     }
+
+    public function testConstructorPropertyPromotion(): void
+    {
+        $valueHolder = $this->createMock(PropertyGenerator::class);
+
+        $constructor = Constructor::generateMethod(
+            new ReflectionClass(ClassWithPromotedProperties::class),
+            $valueHolder
+        );
+
+        self::assertSame('__construct', $constructor->getName());
+        $parameters = $constructor->getParameters();
+        self::assertCount(2, $parameters);
+
+        // Promoted constructor properties should not be doubled, since they are inherited anyway
+        $this->assertSame('int $amount', $parameters['amount']->generate());
+        $this->assertSame('?int $nullableAmount', $parameters['nullableAmount']->generate());
+    }
+
 }

--- a/tests/ProxyManagerTestAsset/ClassWithPromotedProperties.php
+++ b/tests/ProxyManagerTestAsset/ClassWithPromotedProperties.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProxyManagerTestAsset;
+
+/**
+ * Class with a promoted constructor properties
+ *
+ * @license MIT
+ */
+class ClassWithPromotedProperties
+{
+    public function __construct(
+        protected int $amount,
+        protected ?int $nullableAmount
+    ) {
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function getNullableAmount(): ?int
+    {
+        return $this->nullableAmount;
+    }
+}


### PR DESCRIPTION
Since properties are inherited, their declaration should not be doubled.

Issue arises with laminas-code versions, which supports constructor property promotion (at least 4.7, maybe earlier).

Closes #784 

// cc @nicolas-grekas 